### PR TITLE
Fix: Added .gitignores to check-in Editor dirs

### DIFF
--- a/UnityPackages/TouchScript.Android/Assets/.gitignore
+++ b/UnityPackages/TouchScript.Android/Assets/.gitignore
@@ -3,3 +3,7 @@ TouchScript/*
 !TouchScript/Examples
 TouchScript/Examples/General*
 TouchScript/Examples/_misc*
+
+!TouchScript/Editor.meta
+!TouchScript/Editor
+TouchScript/Editor/*

--- a/UnityPackages/TouchScript.Android/Assets/TouchScript/Editor.meta
+++ b/UnityPackages/TouchScript.Android/Assets/TouchScript/Editor.meta
@@ -1,0 +1,5 @@
+fileFormatVersion: 2
+guid: a199e5fe7cefc4b9baf8ca415cf19346
+folderAsset: yes
+DefaultImporter:
+  userData: 

--- a/UnityPackages/TouchScript.Android/Assets/TouchScript/Editor/.gitignore
+++ b/UnityPackages/TouchScript.Android/Assets/TouchScript/Editor/.gitignore
@@ -1,0 +1,3 @@
+# Folder Placeholder gitignore
+# See: http://stackoverflow.com/questions/115983/add-empty-directory-to-git-repository
+!.gitignore

--- a/UnityPackages/TouchScript.TUIO/Assets/.gitignore
+++ b/UnityPackages/TouchScript.TUIO/Assets/.gitignore
@@ -10,3 +10,7 @@ TouchScript/Plugins/*
 !TouchScript/Plugins/TouchScript.TUIO.dll.meta
 !TouchScript/Plugins/TUIOSharp.dll.meta
 !TouchScript/Plugins/OSCSharp.dll.meta
+
+!TouchScript/Editor.meta
+!TouchScript/Editor
+TouchScript/Editor/*

--- a/UnityPackages/TouchScript.TUIO/Assets/TouchScript/Editor.meta
+++ b/UnityPackages/TouchScript.TUIO/Assets/TouchScript/Editor.meta
@@ -1,0 +1,5 @@
+fileFormatVersion: 2
+guid: 7bc891b1a9ce1469c8ef9654277f9a91
+folderAsset: yes
+DefaultImporter:
+  userData: 

--- a/UnityPackages/TouchScript.TUIO/Assets/TouchScript/Editor/.gitignore
+++ b/UnityPackages/TouchScript.TUIO/Assets/TouchScript/Editor/.gitignore
@@ -1,0 +1,3 @@
+# Folder Placeholder gitignore
+# See: http://stackoverflow.com/questions/115983/add-empty-directory-to-git-repository
+!.gitignore

--- a/UnityPackages/TouchScript.Windows7/Assets/.gitignore
+++ b/UnityPackages/TouchScript.Windows7/Assets/.gitignore
@@ -8,3 +8,7 @@ TouchScript/Examples/_misc*
 !TouchScript/Plugins
 TouchScript/Plugins/*
 !TouchScript/Plugins/TouchScript.Windows.dll.meta
+
+!TouchScript/Editor.meta
+!TouchScript/Editor
+TouchScript/Editor/*

--- a/UnityPackages/TouchScript.Windows7/Assets/TouchScript/Editor.meta
+++ b/UnityPackages/TouchScript.Windows7/Assets/TouchScript/Editor.meta
@@ -1,0 +1,5 @@
+fileFormatVersion: 2
+guid: 95fee13ce8b8f4d62bad3cffa211f36e
+folderAsset: yes
+DefaultImporter:
+  userData: 

--- a/UnityPackages/TouchScript.Windows7/Assets/TouchScript/Editor/.gitignore
+++ b/UnityPackages/TouchScript.Windows7/Assets/TouchScript/Editor/.gitignore
@@ -1,0 +1,3 @@
+# Folder Placeholder gitignore
+# See: http://stackoverflow.com/questions/115983/add-empty-directory-to-git-repository
+!.gitignore

--- a/UnityPackages/TouchScript.Windows8/Assets/.gitignore
+++ b/UnityPackages/TouchScript.Windows8/Assets/.gitignore
@@ -8,3 +8,7 @@ TouchScript/Examples/_misc*
 !TouchScript/Plugins
 TouchScript/Plugins/*
 !TouchScript/Plugins/TouchScript.Windows.dll.meta
+
+!TouchScript/Editor.meta
+!TouchScript/Editor
+TouchScript/Editor/*

--- a/UnityPackages/TouchScript.Windows8/Assets/TouchScript/Editor.meta
+++ b/UnityPackages/TouchScript.Windows8/Assets/TouchScript/Editor.meta
@@ -1,0 +1,5 @@
+fileFormatVersion: 2
+guid: 2b3898d6f65844ecea9a5e13e18ecd23
+folderAsset: yes
+DefaultImporter:
+  userData: 

--- a/UnityPackages/TouchScript.Windows8/Assets/TouchScript/Editor/.gitignore
+++ b/UnityPackages/TouchScript.Windows8/Assets/TouchScript/Editor/.gitignore
@@ -1,0 +1,3 @@
+# Folder Placeholder gitignore
+# See: http://stackoverflow.com/questions/115983/add-empty-directory-to-git-repository
+!.gitignore

--- a/UnityPackages/TouchScript.WindowsPhone/Assets/.gitignore
+++ b/UnityPackages/TouchScript.WindowsPhone/Assets/.gitignore
@@ -21,3 +21,7 @@ TouchScript/Plugins/WP8/*
 !TouchScript/Devices
 TouchScript/Devices/Display/*
 !TouchScript/Devices/Display/Windows Phone.*
+
+!TouchScript/Editor.meta
+!TouchScript/Editor
+TouchScript/Editor/*

--- a/UnityPackages/TouchScript.WindowsPhone/Assets/TouchScript/Editor.meta
+++ b/UnityPackages/TouchScript.WindowsPhone/Assets/TouchScript/Editor.meta
@@ -1,0 +1,5 @@
+fileFormatVersion: 2
+guid: fd0e8ae55b58542d9a7a6aa2be2cfe56
+folderAsset: yes
+DefaultImporter:
+  userData: 

--- a/UnityPackages/TouchScript.WindowsPhone/Assets/TouchScript/Editor/.gitignore
+++ b/UnityPackages/TouchScript.WindowsPhone/Assets/TouchScript/Editor/.gitignore
@@ -1,0 +1,3 @@
+# Folder Placeholder gitignore
+# See: http://stackoverflow.com/questions/115983/add-empty-directory-to-git-repository
+!.gitignore

--- a/UnityPackages/TouchScript.WindowsStore/Assets/.gitignore
+++ b/UnityPackages/TouchScript.WindowsStore/Assets/.gitignore
@@ -3,3 +3,7 @@ TouchScript/*
 !TouchScript/Examples
 TouchScript/Examples/General*
 TouchScript/Examples/_misc*
+
+!TouchScript/Editor.meta
+!TouchScript/Editor
+TouchScript/Editor/*

--- a/UnityPackages/TouchScript.WindowsStore/Assets/TouchScript/Editor.meta
+++ b/UnityPackages/TouchScript.WindowsStore/Assets/TouchScript/Editor.meta
@@ -1,0 +1,5 @@
+fileFormatVersion: 2
+guid: e4bc3ea19ebb8441aaae621c6f11bd90
+folderAsset: yes
+DefaultImporter:
+  userData: 

--- a/UnityPackages/TouchScript.WindowsStore/Assets/TouchScript/Editor/.gitignore
+++ b/UnityPackages/TouchScript.WindowsStore/Assets/TouchScript/Editor/.gitignore
@@ -1,0 +1,3 @@
+# Folder Placeholder gitignore
+# See: http://stackoverflow.com/questions/115983/add-empty-directory-to-git-repository
+!.gitignore

--- a/UnityPackages/TouchScript.iOS/Assets/.gitignore
+++ b/UnityPackages/TouchScript.iOS/Assets/.gitignore
@@ -3,3 +3,7 @@ TouchScript/*
 !TouchScript/Examples
 TouchScript/Examples/General*
 TouchScript/Examples/_misc*
+
+!TouchScript/Editor.meta
+!TouchScript/Editor
+TouchScript/Editor/*

--- a/UnityPackages/TouchScript.iOS/Assets/TouchScript/Editor.meta
+++ b/UnityPackages/TouchScript.iOS/Assets/TouchScript/Editor.meta
@@ -1,0 +1,5 @@
+fileFormatVersion: 2
+guid: 824341879a4964a578c32fc9463f634f
+folderAsset: yes
+DefaultImporter:
+  userData: 

--- a/UnityPackages/TouchScript.iOS/Assets/TouchScript/Editor/.gitignore
+++ b/UnityPackages/TouchScript.iOS/Assets/TouchScript/Editor/.gitignore
@@ -1,0 +1,3 @@
+# Folder Placeholder gitignore
+# See: http://stackoverflow.com/questions/115983/add-empty-directory-to-git-repository
+!.gitignore


### PR DESCRIPTION
• Added empty `Assets/TouchScript/Editor` where needed using the .gitignore-placeholder trick (see http://stackoverflow.com/questions/115983/add-empty-directory-to-git-repository).
    » Running `./Build/compile.sh` was failing in multiple spots due to a `cp: directory …/TouchScript/UnityPackages/TouchScript.…/Assets/TouchScript/Editor does not exist` error.
    » Same failure when opening TouchScript.sln in Unity's MonoDevelop and trying to `Build TouchScript`.
    » Now builds fine on OS X with Unity 4.6 with a clean `git clone …/TouchScript.git && cd TouchScript && git submodule update --init --recursive && ln -s /Applications/Unity/Unity.app/Contents/Frameworks/Managed/* Lib/'' && ./Build/compile.sh`
    • Also updated containing Assets dirs' gitignores to recognize the new Editor-dir-gitignores.
