### PR TITLE
Added null check for SendMessageTarget

### DIFF
--- a/TouchScript/Gestures/PressGesture.cs
+++ b/TouchScript/Gestures/PressGesture.cs
@@ -102,7 +102,7 @@ namespace TouchScript.Gestures
         {
             base.onRecognized();
             if (pressedInvoker != null) pressedInvoker(this, EventArgs.Empty);
-            if (UseSendMessage) SendMessageTarget.SendMessage(PRESS_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
+            if (UseSendMessage && SendMessageTarget != null) SendMessageTarget.SendMessage(PRESS_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
         }
 
         #endregion


### PR DESCRIPTION
When scene was loaded with Message Target set, the line:
if (UseSendMessage) SendMessageTarget.SendMessage(PRESS_MESSAGE, this, SendMessageOptions.DontRequireReceiver); 
Was throwing null reference exception and causing touch hang on devices.