### PR TITLE
Touchscript fix for Unity 5

### DIFF
--- a/TouchScript/Behaviors/FullscreenTarget.cs
+++ b/TouchScript/Behaviors/FullscreenTarget.cs
@@ -50,6 +50,7 @@ namespace TouchScript.Behaviors
         private void Update()
         {
             var box = GetComponent<BoxCollider>();
+            var camera = GetComponent<Camera>();
 
             var h = 2 * Mathf.Tan(camera.fieldOfView / 360 * Mathf.PI);
             if (Type == TargetType.Background)

--- a/TouchScript/Gestures/Simple/Transform2DGestureBase.cs
+++ b/TouchScript/Gestures/Simple/Transform2DGestureBase.cs
@@ -130,7 +130,7 @@ namespace TouchScript.Gestures.Simple
         {
             base.OnEnable();
 
-            cachedCollider = collider;
+            cachedCollider = GetComponent<Collider>();
             updateProjectionPlane();
         }
 

--- a/TouchScript/Layers/CameraLayer2D.cs
+++ b/TouchScript/Layers/CameraLayer2D.cs
@@ -114,7 +114,7 @@ namespace TouchScript.Layers
                     if (sprite1.sortingOrder > sprite2.sortingOrder) return -1;
                 }
 
-                var cameraPos = camera.transform.position;
+                var cameraPos = GetComponent<Camera>().transform.position;
                 var distA = (a.transform.position - cameraPos).sqrMagnitude;
                 var distB = (b.transform.position - cameraPos).sqrMagnitude;
                 return distA < distB ? -1 : 1;

--- a/TouchScript/TouchManager.cs
+++ b/TouchScript/TouchManager.cs
@@ -125,7 +125,7 @@ namespace TouchScript
         /// <summary>
         /// TouchScript version.
         /// </summary>
-        public static readonly Version VERSION = new Version(6, 2);
+        public static readonly Version VERSION = new Version(6, 4);
 
         #endregion
 


### PR DESCRIPTION
In Unity 5, the property 'camera' on Component has been deprecated in
favour of doing 'GetComponent<Camera>' style retrievals of components on
game objects.

Similarly for collider etc. Anyone porting from 4.6 can fix it with these changes.