### PR TITLE
Fixed screen size causing bad positions in TuioInput

### DIFF
--- a/TouchScript.Inputs/TouchScript.TUIO/InputSources/TuioInput.cs
+++ b/TouchScript.Inputs/TouchScript.TUIO/InputSources/TuioInput.cs
@@ -147,6 +147,9 @@ namespace TouchScript.InputSources
         {
             base.OnEnable();
 
+            screenWidth = Screen.width;
+            screenHeight = Screen.height;
+
             cursorProcessor = new CursorProcessor();
             cursorProcessor.CursorAdded += OnCursorAdded;
             cursorProcessor.CursorUpdated += OnCursorUpdated;


### PR DESCRIPTION
Set screen width and height in OnEnable to correctly position tuio input made after OnEnable but before Update is first called. These touches can occur if tuio objects are already present when the app launches/scripts are starting.

Previously, the screen width and height were 0 until the first Update was called, so initial touches made before the first Update were always set to screen position 0,0.