### PR TITLE
Gestures handle exceptions properly

### DIFF
--- a/TouchScript/Gestures/FlickGesture.cs
+++ b/TouchScript/Gestures/FlickGesture.cs
@@ -235,7 +235,7 @@ namespace TouchScript.Gestures
         protected override void onRecognized()
         {
             base.onRecognized();
-            if (flickedInvoker != null) flickedInvoker(this, EventArgs.Empty);
+            flickedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
             if (UseSendMessage && SendMessageTarget != null) SendMessageTarget.SendMessage(FLICK_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
         }
 

--- a/TouchScript/Gestures/Gesture.cs
+++ b/TouchScript/Gestures/Gesture.cs
@@ -194,7 +194,7 @@ namespace TouchScript.Gestures
                         break;
                 }
 
-                if (stateChangedInvoker != null) stateChangedInvoker(this, new GestureStateChangeEventArgs(state, PreviousState));
+                stateChangedInvoker.InvokeHandleExceptions(this, new GestureStateChangeEventArgs(state, PreviousState));
                 if (useSendMessage && sendStateChangeMessages && SendMessageTarget != null) sendMessageTarget.SendMessage(STATE_CHANGE_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
             }
         }

--- a/TouchScript/Gestures/LongPressGesture.cs
+++ b/TouchScript/Gestures/LongPressGesture.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using TouchScript.Utils;
 using TouchScript.Utils.Attributes;
 using UnityEngine;
 
@@ -154,7 +155,7 @@ namespace TouchScript.Gestures
         protected override void onRecognized()
         {
             base.onRecognized();
-            if (longPressedInvoker != null) longPressedInvoker(this, EventArgs.Empty);
+            longPressedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
             if (UseSendMessage && SendMessageTarget != null) SendMessageTarget.SendMessage(LONG_PRESS_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
         }
 

--- a/TouchScript/Gestures/MetaGesture.cs
+++ b/TouchScript/Gestures/MetaGesture.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using TouchScript.Utils;
 using UnityEngine;
 
 namespace TouchScript.Gestures
@@ -92,10 +93,8 @@ namespace TouchScript.Gestures
             if (State == GestureState.Possible) setState(GestureState.Began);
 
             var length = touches.Count;
-            if (touchBeganInvoker != null)
-            {
-                for (var i = 0; i < length; i++) touchBeganInvoker(this, new MetaGestureEventArgs(touches[i]));
-            }
+            for (var i = 0; i < length; i++)
+                touchBeganInvoker.InvokeHandleExceptions(this, new MetaGestureEventArgs(touches[i]));
             if (UseSendMessage && SendMessageTarget != null)
             {
                 for (var i = 0; i < length; i++) SendMessageTarget.SendMessage(TOUCH_BEGAN_MESSAGE, touches[i], SendMessageOptions.DontRequireReceiver);
@@ -110,10 +109,8 @@ namespace TouchScript.Gestures
             if (State == GestureState.Began || State == GestureState.Changed) setState(GestureState.Changed);
 
             var length = touches.Count;
-            if (touchMovedInvoker != null)
-            {
-                for (var i = 0; i < length; i++) touchMovedInvoker(this, new MetaGestureEventArgs(touches[i]));
-            }
+            for (var i = 0; i < length; i++)
+                touchMovedInvoker.InvokeHandleExceptions(this, new MetaGestureEventArgs(touches[i]));
             if (UseSendMessage && SendMessageTarget != null)
             {
                 for (var i = 0; i < length; i++) SendMessageTarget.SendMessage(TOUCH_MOVED_MESSAGE, touches[i], SendMessageOptions.DontRequireReceiver);
@@ -128,10 +125,8 @@ namespace TouchScript.Gestures
             if ((State == GestureState.Began || State == GestureState.Changed) && activeTouches.Count == 0) setState(GestureState.Ended);
 
             var length = touches.Count;
-            if (touchEndedInvoker != null)
-            {
-                for (var i = 0; i < length; i++) touchEndedInvoker(this, new MetaGestureEventArgs(touches[i]));
-            }
+            for (var i = 0; i < length; i++)
+                touchEndedInvoker.InvokeHandleExceptions(this, new MetaGestureEventArgs(touches[i]));
             if (UseSendMessage && SendMessageTarget != null)
             {
                 for (var i = 0; i < length; i++) SendMessageTarget.SendMessage(TOUCH_ENDED_MESSAGE, touches[i], SendMessageOptions.DontRequireReceiver);
@@ -146,10 +141,8 @@ namespace TouchScript.Gestures
             if ((State == GestureState.Began || State == GestureState.Changed) && activeTouches.Count == 0) setState(GestureState.Ended);
 
             var length = touches.Count;
-            if (touchCancelledInvoker != null)
-            {
-                for (var i = 0; i < length; i++) touchCancelledInvoker(this, new MetaGestureEventArgs(touches[i]));
-            }
+            for (var i = 0; i < length; i++)
+                touchCancelledInvoker.InvokeHandleExceptions(this, new MetaGestureEventArgs(touches[i]));
             if (UseSendMessage && SendMessageTarget != null)
             {
                 for (var i = 0; i < length; i++) SendMessageTarget.SendMessage(TOUCH_CANCELLED_MESSAGE, touches[i], SendMessageOptions.DontRequireReceiver);

--- a/TouchScript/Gestures/PressGesture.cs
+++ b/TouchScript/Gestures/PressGesture.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using TouchScript.Utils;
 using TouchScript.Utils.Attributes;
 using UnityEngine;
 
@@ -101,7 +102,7 @@ namespace TouchScript.Gestures
         protected override void onRecognized()
         {
             base.onRecognized();
-            if (pressedInvoker != null) pressedInvoker(this, EventArgs.Empty);
+            pressedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
             if (UseSendMessage && SendMessageTarget != null) SendMessageTarget.SendMessage(PRESS_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
         }
 

--- a/TouchScript/Gestures/ReleaseGesture.cs
+++ b/TouchScript/Gestures/ReleaseGesture.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using TouchScript.Utils;
 using TouchScript.Utils.Attributes;
 using UnityEngine;
 
@@ -101,7 +102,7 @@ namespace TouchScript.Gestures
         protected override void onRecognized()
         {
             base.onRecognized();
-            if (releasedInvoker != null) releasedInvoker(this, EventArgs.Empty);
+            releasedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
             if (UseSendMessage && SendMessageTarget != null) SendMessageTarget.SendMessage(RELEASE_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
         }
 

--- a/TouchScript/Gestures/Simple/SimplePanGesture.cs
+++ b/TouchScript/Gestures/Simple/SimplePanGesture.cs
@@ -192,8 +192,8 @@ namespace TouchScript.Gestures.Simple
         protected override void onBegan()
         {
             base.onBegan();
-            if (panStartedInvoker != null) panStartedInvoker(this, EventArgs.Empty);
-            if (pannedInvoker != null) pannedInvoker(this, EventArgs.Empty);
+            panStartedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
+            pannedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
             if (UseSendMessage && SendMessageTarget != null)
             {
                 SendMessageTarget.SendMessage(PAN_START_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
@@ -205,7 +205,7 @@ namespace TouchScript.Gestures.Simple
         protected override void onChanged()
         {
             base.onChanged();
-            if (pannedInvoker != null) pannedInvoker(this, EventArgs.Empty);
+            pannedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
             if (UseSendMessage && SendMessageTarget != null) SendMessageTarget.SendMessage(PAN_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
         }
 
@@ -213,7 +213,7 @@ namespace TouchScript.Gestures.Simple
         protected override void onRecognized()
         {
             base.onRecognized();
-            if (panCompletedInvoker != null) panCompletedInvoker(this, EventArgs.Empty);
+            panCompletedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
             if (UseSendMessage && SendMessageTarget != null) SendMessageTarget.SendMessage(PAN_COMPLETE_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
         }
 
@@ -223,7 +223,7 @@ namespace TouchScript.Gestures.Simple
             base.onFailed();
             if (PreviousState != GestureState.Possible)
             {
-                if (panCompletedInvoker != null) panCompletedInvoker(this, EventArgs.Empty);
+                panCompletedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
                 if (UseSendMessage && SendMessageTarget != null) SendMessageTarget.SendMessage(PAN_COMPLETE_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
             }
         }
@@ -234,7 +234,7 @@ namespace TouchScript.Gestures.Simple
             base.onCancelled();
             if (PreviousState != GestureState.Possible)
             {
-                if (panCompletedInvoker != null) panCompletedInvoker(this, EventArgs.Empty);
+                panCompletedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
                 if (UseSendMessage && SendMessageTarget != null) SendMessageTarget.SendMessage(PAN_COMPLETE_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
             }
         }

--- a/TouchScript/Gestures/Simple/SimpleRotateGesture.cs
+++ b/TouchScript/Gestures/Simple/SimpleRotateGesture.cs
@@ -196,8 +196,8 @@ namespace TouchScript.Gestures.Simple
         protected override void onBegan()
         {
             base.onBegan();
-            if (rotateStartedInvoker != null) rotateStartedInvoker(this, EventArgs.Empty);
-            if (rotatedInvoker != null) rotatedInvoker(this, EventArgs.Empty);
+            rotateStartedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
+            rotatedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
             if (UseSendMessage && SendMessageTarget != null)
             {
                 SendMessageTarget.SendMessage(ROTATE_START_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
@@ -209,7 +209,7 @@ namespace TouchScript.Gestures.Simple
         protected override void onChanged()
         {
             base.onChanged();
-            if (rotatedInvoker != null) rotatedInvoker(this, EventArgs.Empty);
+            rotatedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
             if (UseSendMessage && SendMessageTarget != null) SendMessageTarget.SendMessage(ROTATE_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
         }
 
@@ -217,7 +217,7 @@ namespace TouchScript.Gestures.Simple
         protected override void onRecognized()
         {
             base.onRecognized();
-            if (rotateCompletedInvoker != null) rotateCompletedInvoker(this, EventArgs.Empty);
+            rotateCompletedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
             if (UseSendMessage && SendMessageTarget != null) SendMessageTarget.SendMessage(ROTATE_COMPLETE_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
         }
 
@@ -227,7 +227,7 @@ namespace TouchScript.Gestures.Simple
             base.onFailed();
             if (PreviousState != GestureState.Possible)
             {
-                if (rotateCompletedInvoker != null) rotateCompletedInvoker(this, EventArgs.Empty);
+                rotateCompletedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
                 if (UseSendMessage && SendMessageTarget != null) SendMessageTarget.SendMessage(ROTATE_COMPLETE_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
             }
         }
@@ -238,7 +238,7 @@ namespace TouchScript.Gestures.Simple
             base.onCancelled();
             if (PreviousState != GestureState.Possible)
             {
-                if (rotateCompletedInvoker != null) rotateCompletedInvoker(this, EventArgs.Empty);
+                rotateCompletedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
                 if (UseSendMessage && SendMessageTarget != null) SendMessageTarget.SendMessage(ROTATE_COMPLETE_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
             }
         }

--- a/TouchScript/Gestures/Simple/SimpleScaleGesture.cs
+++ b/TouchScript/Gestures/Simple/SimpleScaleGesture.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using TouchScript.Utils;
 using UnityEngine;
 
 namespace TouchScript.Gestures.Simple
@@ -181,8 +182,8 @@ namespace TouchScript.Gestures.Simple
         protected override void onBegan()
         {
             base.onBegan();
-            if (scaleStartedInvoker != null) scaleStartedInvoker(this, EventArgs.Empty);
-            if (scaledInvoker != null) scaledInvoker(this, EventArgs.Empty);
+            scaleStartedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
+            scaledInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
             if (UseSendMessage && SendMessageTarget != null)
             {
                 SendMessageTarget.SendMessage(SCALE_START_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
@@ -194,7 +195,7 @@ namespace TouchScript.Gestures.Simple
         protected override void onChanged()
         {
             base.onChanged();
-            if (scaledInvoker != null) scaledInvoker(this, EventArgs.Empty);
+            scaledInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
             if (UseSendMessage && SendMessageTarget != null) SendMessageTarget.SendMessage(SCALE_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
         }
 
@@ -202,7 +203,7 @@ namespace TouchScript.Gestures.Simple
         protected override void onRecognized()
         {
             base.onRecognized();
-            if (scaleCompletedInvoker != null) scaleCompletedInvoker(this, EventArgs.Empty);
+            scaleCompletedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
             if (UseSendMessage && SendMessageTarget != null) SendMessageTarget.SendMessage(SCALE_COMPLETE_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
         }
 
@@ -212,7 +213,7 @@ namespace TouchScript.Gestures.Simple
             base.onFailed();
             if (PreviousState != GestureState.Possible)
             {
-                if (scaleCompletedInvoker != null) scaleCompletedInvoker(this, EventArgs.Empty);
+                scaleCompletedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
                 if (UseSendMessage && SendMessageTarget != null) SendMessageTarget.SendMessage(SCALE_COMPLETE_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
             }
         }
@@ -223,7 +224,7 @@ namespace TouchScript.Gestures.Simple
             base.onCancelled();
             if (PreviousState != GestureState.Possible)
             {
-                if (scaleCompletedInvoker != null) scaleCompletedInvoker(this, EventArgs.Empty);
+                scaleCompletedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
                 if (UseSendMessage && SendMessageTarget != null) SendMessageTarget.SendMessage(SCALE_COMPLETE_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
             }
         }

--- a/TouchScript/Gestures/TapGesture.cs
+++ b/TouchScript/Gestures/TapGesture.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using TouchScript.Utils;
 using TouchScript.Utils.Attributes;
 using UnityEngine;
 
@@ -194,7 +195,7 @@ namespace TouchScript.Gestures
             base.onRecognized();
 
             StopCoroutine("wait");
-            if (tappedInvoker != null) tappedInvoker(this, EventArgs.Empty);
+            tappedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
             if (UseSendMessage && SendMessageTarget != null) SendMessageTarget.SendMessage(TAP_MESSAGE, this, SendMessageOptions.DontRequireReceiver);
         }
 

--- a/TouchScript/Layers/TouchLayer.cs
+++ b/TouchScript/Layers/TouchLayer.cs
@@ -143,7 +143,7 @@ namespace TouchScript.Layers
                 touch.Layer = this;
                 touch.Hit = hit;
                 if (hit != null) touch.Target = hit.Transform;
-                if (touchBeganInvoker != null) touchBeganInvoker(this, new TouchLayerEventArgs(touch));
+                touchBeganInvoker.InvokeHandleExceptions(this, new TouchLayerEventArgs(touch));
                 return true;
             }
             return false;

--- a/TouchScript/TouchManagerInstance.cs
+++ b/TouchScript/TouchManagerInstance.cs
@@ -11,6 +11,7 @@ using TouchScript.Devices.Display;
 using TouchScript.Hit;
 using TouchScript.InputSources;
 using TouchScript.Layers;
+using TouchScript.Utils;
 using UnityEngine;
 
 namespace TouchScript
@@ -470,7 +471,7 @@ namespace TouchScript
                     }
                 }
 
-                if (touchesBeganInvoker != null) touchesBeganInvoker(this, new TouchEventArgs(touchesList));
+                touchesBeganInvoker.InvokeHandleExceptions(this, new TouchEventArgs(touchesList));
                 touchesBegan.Clear();
             }
         }
@@ -491,7 +492,7 @@ namespace TouchScript
                     }
                 }
 
-                if (touchesMovedInvoker != null) touchesMovedInvoker(this, new TouchEventArgs(updated));
+                touchesMovedInvoker.InvokeHandleExceptions(this, new TouchEventArgs(updated));
                 touchesUpdated.Clear();
             }
         }
@@ -510,7 +511,7 @@ namespace TouchScript
                     if (touch.Layer != null) touch.Layer.EndTouch(touch);
                 }
 
-                if (touchesEndedInvoker != null) touchesEndedInvoker(this, new TouchEventArgs(updated));
+                touchesEndedInvoker.InvokeHandleExceptions(this, new TouchEventArgs(updated));
                 touchesEnded.Clear();
             }
         }
@@ -529,21 +530,21 @@ namespace TouchScript
                     if (touch.Layer != null) touch.Layer.CancelTouch(touch);
                 }
 
-                if (touchesCancelledInvoker != null) touchesCancelledInvoker(this, new TouchEventArgs(updated));
+                touchesCancelledInvoker.InvokeHandleExceptions(this, new TouchEventArgs(updated));
                 touchesCancelled.Clear();
             }
         }
 
         private void updateTouches()
         {
-            if (frameStartedInvoker != null) frameStartedInvoker(this, EventArgs.Empty);
+            frameStartedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
 
             lock (touchesBegan) updateBegan();
             lock (touchesUpdated) updateUpdated();
             lock (touchesEnded) updateEnded();
             lock (touchesCancelled) updateCancelled();
 
-            if (frameFinishedInvoker != null) frameFinishedInvoker(this, EventArgs.Empty);
+            frameFinishedInvoker.InvokeHandleExceptions(this, EventArgs.Empty);
         }
 
         #endregion

--- a/TouchScript/TouchScript.csproj
+++ b/TouchScript/TouchScript.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Devices\Display\IDisplayDevice.cs" />
     <Compile Include="GestureManager.cs" />
     <Compile Include="GestureManagerInstance.cs" />
+    <Compile Include="Utils\EventHandlerExtensions.cs" />
     <Compile Include="Gestures\FlickGesture.cs" />
     <Compile Include="Gestures\Gesture.cs" />
     <Compile Include="Gestures\LongPressGesture.cs" />

--- a/TouchScript/Utils/EventHandlerExtensions.cs
+++ b/TouchScript/Utils/EventHandlerExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using UnityEngine;
+
+namespace TouchScript.Utils
+{
+    static internal class EventHandlerExtensions
+    {
+        static public Exception InvokeHandleExceptions<T>(this EventHandler<T> handler, object sender, T args)
+            where T : EventArgs
+        {
+            if (handler != null)
+            {
+                try
+                {
+                    handler(sender, args);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogException(ex);
+                    return ex;
+                }
+            }
+            return null;
+        }
+
+        static public Exception InvokeHandleExceptions(this EventHandler handler, object sender, EventArgs args)
+        {
+            if (handler != null)
+            {
+                try
+                {
+                    handler(sender, args);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogException(ex);
+                    return ex;
+                }
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Previously whenever event handlers threw any exception, it broke the
internal
state of TouchScript, which then started printing many error messages.
Now exceptions are handled and printed as a log message to Unity
console.

This could be optional in future, because now it prevents developer from
actually debugging the code where the exceptions are thrown.

This solves: https://github.com/TouchScript/TouchScript/issues/165