### PR TITLE
Fixed CameraLayer2D to work with Unity4.6 (and up) UI system.

### DIFF
--- a/TouchScript/Layers/CameraLayerBase.cs
+++ b/TouchScript/Layers/CameraLayerBase.cs
@@ -36,6 +36,8 @@ namespace TouchScript.Layers
             }
         }
 
+        public Func<Vector2, Vector2> ScreenCoordinateRemapper { get; set; }
+
         #endregion
 
         #region Private variables
@@ -59,6 +61,8 @@ namespace TouchScript.Layers
 
             if (_camera == null) return LayerHitResult.Error;
             if (_camera.enabled == false || _camera.gameObject.activeInHierarchy == false) return LayerHitResult.Miss;
+
+            if (ScreenCoordinateRemapper != null) position = ScreenCoordinateRemapper(position);
             if (!_camera.pixelRect.Contains(position)) return LayerHitResult.Miss;
 
             var ray = _camera.ScreenPointToRay(position);
@@ -68,6 +72,7 @@ namespace TouchScript.Layers
         /// <inheritdoc />
         public override Vector3 ProjectTo(Vector2 screenPosition, Plane projectionPlane)
         {
+            if (ScreenCoordinateRemapper != null) screenPosition = ScreenCoordinateRemapper(screenPosition);
             return ProjectionUtils.CameraToPlaneProjection(screenPosition, _camera, projectionPlane);
         }
 


### PR DESCRIPTION
This is just a small adjustment to CameraLayer2D to make it work with the UI system introduced in Unity 4.6.
