### PR TITLE
Fix 2DCameraLayer hit sorting

### DIFF
--- a/TouchScript/Layers/CameraLayer2D.cs
+++ b/TouchScript/Layers/CameraLayer2D.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using TouchScript.Hit;
+using TouchScript.Utils;
 using UnityEngine;
 using UnityEngine.Serialization;
 
@@ -32,6 +33,7 @@ namespace TouchScript.Layers
 
         private void OnEnable()
         {
+			layerIds = LayerUtils.GetSortingLayerUniqueIDs ();
             sortedHits = new List<RaycastHit2D>();
             layerById.Clear();
             for (var i = 0; i < layerIds.Length; i++)

--- a/TouchScript/Layers/CameraLayer2D.cs
+++ b/TouchScript/Layers/CameraLayer2D.cs
@@ -33,7 +33,7 @@ namespace TouchScript.Layers
 
         private void OnEnable()
         {
-			layerIds = LayerUtils.GetSortingLayerUniqueIDs ();
+            layerIds = LayerUtils.GetSortingLayerUniqueIDs ();
             sortedHits = new List<RaycastHit2D>();
             layerById.Clear();
             for (var i = 0; i < layerIds.Length; i++)

--- a/TouchScript/Layers/CameraLayer2D.cs
+++ b/TouchScript/Layers/CameraLayer2D.cs
@@ -115,8 +115,8 @@ namespace TouchScript.Layers
             {
                 if (a.collider.transform == b.collider.transform) return 0;
 
-                var sprite1 = a.transform.GetComponent<SpriteRenderer>();
-                var sprite2 = b.transform.GetComponent<SpriteRenderer>();
+                var sprite1 = a.collider.transform.GetComponent<SpriteRenderer>();
+                var sprite2 = b.collider.transform.GetComponent<SpriteRenderer>();
                 if (sprite1 != null && sprite2 != null)
                 {
                     int s1Id, s2Id;

--- a/TouchScript/Utils/LayerUtils.cs
+++ b/TouchScript/Utils/LayerUtils.cs
@@ -15,11 +15,13 @@ namespace TouchScript.Utils
     /// </summary>
     public static class LayerUtils
     {
-		// Get the sorting layer names
+    	/// <summary>
+		/// Get the sorting layer names
+    	/// </summary>
 		public static string[] GetSortingLayerNames() {
 			Type internalEditorUtilityType = typeof(InternalEditorUtility);
 			PropertyInfo sortingLayersProperty = internalEditorUtilityType.GetProperty("sortingLayerNames", BindingFlags.Static | BindingFlags.NonPublic);
-			return (string[])sortingLayersProperty.GetValue(null, new object[0]) as string[];
+			return sortingLayersProperty.GetValue(null, new object[0]) as string[];
 		}
 
 		/// <summary>

--- a/TouchScript/Utils/LayerUtils.cs
+++ b/TouchScript/Utils/LayerUtils.cs
@@ -1,0 +1,35 @@
+/*
+ * @author Olli Niskanen
+ * Code inspired by Ivan Murashko
+ * http://answers.unity3d.com/questions/585108/how-do-you-access-sorting-layers-via-scripting.html
+ */
+
+using System;
+using System.Reflection;
+using UnityEditorInternal;
+
+namespace TouchScript.Utils
+{
+    /// <summary>
+    /// Utils to access Unity layers
+    /// </summary>
+    public static class LayerUtils
+    {
+		// Get the sorting layer names
+		public static string[] GetSortingLayerNames() {
+			Type internalEditorUtilityType = typeof(InternalEditorUtility);
+			PropertyInfo sortingLayersProperty = internalEditorUtilityType.GetProperty("sortingLayerNames", BindingFlags.Static | BindingFlags.NonPublic);
+			return (string[])sortingLayersProperty.GetValue(null, new object[0]) as string[];
+		}
+
+		/// <summary>
+		/// Get the unique sorting layer IDs
+		/// </summary>
+		public static int[] GetSortingLayerUniqueIDs() 
+		{
+			Type internalEditorUtilityType = typeof(InternalEditorUtility);
+			PropertyInfo sortingLayerUniqueIDsProperty = internalEditorUtilityType.GetProperty("sortingLayerUniqueIDs", BindingFlags.Static | BindingFlags.NonPublic);
+			return sortingLayerUniqueIDsProperty.GetValue(null, new System.Object[0]) as int[];
+		}
+    }
+}


### PR DESCRIPTION
The 2D camera layer sorting layer comparisons were always failing due to it never updating the sorting layers. I added a line to fetch the sorting layers in the OnEnable method.

Another fix is to compare the layers of renderers of RaycastHit2D.collider.transform instead of RaycastHit2D.transform. For some reason these were not the same in our development scene with a complex hierarchy of multiple renderers and colliders.