### PR TITLE
TouchScriptInputModule repeat delay and .NET 3.5 compatibility

### DIFF
--- a/TouchScript/Behaviors/TouchScriptInputModule.cs
+++ b/TouchScript/Behaviors/TouchScriptInputModule.cs
@@ -66,9 +66,15 @@ namespace TouchScript.Behaviors
         private string cancelButton = "Cancel";
 
         [SerializeField]
-        private float inputActionsPerSecond = 10;
+        private float inputActionsPerSecond = 10f;
+
+        [SerializeField]
+        private float repeatDelay = 0.5f;
 
         private float nextActionTime;
+
+        private MoveDirection lastMoveDirection;
+        private float lastMoveStartTime;
 
         #endregion
 
@@ -431,8 +437,18 @@ namespace TouchScript.Behaviors
 
             Vector2 movement = getRawMoveVector();
             var axisEventData = GetAxisEventData(movement.x, movement.y, 0.6f);
-            if (!Mathf.Approximately(axisEventData.moveVector.x, 0f)
-                || !Mathf.Approximately(axisEventData.moveVector.y, 0f))
+            MoveDirection moveDir = axisEventData.moveDir;
+
+            // Repeat delay
+            if (moveDir != lastMoveDirection) {
+                lastMoveDirection = moveDir;
+                lastMoveStartTime = time;
+            } else {
+                if (time < lastMoveStartTime + repeatDelay)
+                    return false;
+            }
+
+            if (moveDir != MoveDirection.None)
             {
                 ExecuteEvents.Execute(eventSystem.currentSelectedGameObject, axisEventData, ExecuteEvents.moveHandler);
             }

--- a/TouchScript/Gestures/Gesture.cs
+++ b/TouchScript/Gestures/Gesture.cs
@@ -557,7 +557,7 @@ namespace TouchScript.Gestures
 
         /// <summary>
         /// </summary>
-        public void Cancel(bool cancelTouches = false, bool redispatchTouches = false)
+        public void Cancel(bool cancelTouches, bool redispatchTouches)
         {
             switch (state)
             {
@@ -575,6 +575,7 @@ namespace TouchScript.Gestures
                 touchManager.CancelTouch(activeTouches[i].Id, redispatchTouches);
             }
         }
+        public void Cancel() { Cancel(false, false); }
 
         #endregion
 

--- a/TouchScript/ITouchManager.cs
+++ b/TouchScript/ITouchManager.cs
@@ -168,7 +168,8 @@ namespace TouchScript
 
         /// <summary>
         /// </summary>
-        void CancelTouch(int id, bool redispatch = false);
+        void CancelTouch(int id, bool redispatch);
+        void CancelTouch(int id);
     }
 
     /// <summary>

--- a/TouchScript/TouchManagerInstance.cs
+++ b/TouchScript/TouchManagerInstance.cs
@@ -285,10 +285,11 @@ namespace TouchScript
         }
 
         /// <inheritdoc />
-        public void CancelTouch(int id, bool redispatch = false)
+        public void CancelTouch(int id, bool redispatch)
         {
             touchesManuallyCancelled.Add(new CancelledTouch(id, redispatch));
         }
+        public void CancelTouch(int id) { CancelTouch(id, false); }
 
         #endregion
 
@@ -752,10 +753,15 @@ namespace TouchScript
             public int Id;
             public bool Redispatch;
 
-            public CancelledTouch(int id, bool redispatch = false)
+            public CancelledTouch(int id, bool redispatch)
             {
                 Id = id;
                 Redispatch = redispatch;
+            }
+            public CancelledTouch(int id)
+            {
+                Id = id;
+                Redispatch = false;
             }
 
         }


### PR DESCRIPTION
I have implemented repeatDelay in the InputModule, similar in functionality to Unity's StandaloneInputModule.
It's a must-have when combining with non-pointer devices (keyboard, joystick, gamepad).

Also, I failed to compile the recent version because it required .NET 4.0 for using default parameters.
Unity does not seem to support .NET 4.0 - I get an error when importing the .NET 4.0 DLLs.
I have changed the methods to use overloads instead, so the solution is again .NET 3.5 compatible.