### PR TITLE
Fixes incorrect sorting order of hit objects in CameraLayer2D.

### DIFF
--- a/Source/Assets/TouchScript/Scripts/Layers/CameraLayer2D.cs
+++ b/Source/Assets/TouchScript/Scripts/Layers/CameraLayer2D.cs
@@ -132,10 +132,7 @@ namespace TouchScript.Layers
                     if (sprite1.sortingOrder > sprite2.sortingOrder) return -1;
                 }
 
-                var cameraPos = GetComponent<Camera>().transform.position;
-                var distA = (a.transform.position - cameraPos).sqrMagnitude;
-                var distB = (b.transform.position - cameraPos).sqrMagnitude;
-                return distA < distB ? -1 : 1;
+                return a.distance < b.distance ? -1 : 1;
             });
         }
 


### PR DESCRIPTION
Using the distance between the center of the hit objects to the cameraPos will result in incorrect or unexpected sort order in the situation when both the objects' centers (transform.position) are not in a straight line with the camera's, or even when one object is significantly larger than the other.
Please see [this image](http://imgur.com/DUfXSGk) for an illustration of the issue.

![touchscript-cameralayer2d-sorthits-issue](https://cloud.githubusercontent.com/assets/2024912/16184717/335d556e-36f1-11e6-9269-1363662edbd7.png)

Using the distance between the raycast origin and the point of impact (already provided in RaycastHit2D) gives the correct results.