### PR TITLE
Fix. Touch Proxy correctly display information

### DIFF
--- a/Source/Assets/TouchScript/Scripts/Behaviors/Visualizer/TouchProxy.cs
+++ b/Source/Assets/TouchScript/Scripts/Behaviors/Visualizer/TouchProxy.cs
@@ -34,7 +34,11 @@ namespace TouchScript.Behaviors.Visualizer
             gameObject.name = stringBuilder.ToString();
 
             if (Text == null) return;
-            if (!ShowTouchId && !ShowTags) return;
+            if (!ShowTouchId && !ShowTags)
+            {
+                Text.text = "";
+                return;
+            }
 
             stringBuilder.Length = 0;
             if (ShowTouchId)


### PR DESCRIPTION
*Fix, If the user isn't using ShowTouchId and ShowTags, clean the text, to avoid displaying the default text or last one.