### PR TITLE
UILayer - added LayerMark property for specifying which layers should be touchable and which not

### DIFF
--- a/Source/Assets/TouchScript/Scripts/Layers/UILayer.cs
+++ b/Source/Assets/TouchScript/Scripts/Layers/UILayer.cs
@@ -21,11 +21,24 @@ namespace TouchScript.Layers
     {
         #region Public properties
 
+        /// <summary>
+        /// Gets or sets the layer mask which is used to select layers which should be touchable from this layer.
+        /// </summary>
+        /// <value>A mask to include/exclude objects from possibly touchable list.</value>
+        public LayerMask LayerMask
+        {
+          get { return layerMask; }
+          set { layerMask = value; }
+        }
+
         #endregion
 
         #region Private variables
 
         private static UILayer instance;
+
+        [SerializeField]
+        private LayerMask layerMask = -1;
 
         [NonSerialized]
         private List<RaycastResult> raycastResultCache = new List<RaycastResult>(20);
@@ -157,6 +170,9 @@ namespace TouchScript.Layers
             if (!(raycastHit.module is GraphicRaycaster)) return HitTest.ObjectHitResult.Miss;
             var go = raycastHit.gameObject;
             if (go == null) return HitTest.ObjectHitResult.Miss;
+
+            if (((1 << go.layer) & LayerMask) == 0) return HitTest.ObjectHitResult.Miss;
+
             go.GetComponents(tmpHitTestList);
             var count = tmpHitTestList.Count;
             if (count == 0) return HitTest.ObjectHitResult.Hit;


### PR DESCRIPTION
UILayer simply takes all GameObjects on Canvas and makes them toucable. However, one would like to decide which UI elements should be touchable and which not - this pull requests add a public LayerMask to specify UI Layers which are touchable