### PR TITLE
Bugfix/unity5.4 support

### DIFF
--- a/Source/Assets/TouchScript/Examples/_misc/Scripts/Runner.cs
+++ b/Source/Assets/TouchScript/Examples/_misc/Scripts/Runner.cs
@@ -34,6 +34,10 @@ namespace TouchScript.Examples
 
             layer = GetComponent<UILayer>();
 
+#if UNITY_5_4
+            SceneManager.sceneLoaded += LevelWasLoaded;
+#endif
+
 #if UNITY_5_3 || UNITY_5_4
             if (SceneManager.GetActiveScene().name == "Examples" && SceneManager.sceneCountInBuildSettings > 1)
 #else
@@ -44,9 +48,17 @@ namespace TouchScript.Examples
             }
         }
 
-        private void OnLevelWasLoaded(int num)
+
+#if !UNITY_5_4
+        private void OnLevelWasLoaded(int value)
         {
             TouchManager.Instance.AddLayer(layer, 0);
         }
+#else
+        private void LevelWasLoaded(Scene scene, LoadSceneMode mode)
+        {
+            TouchManager.Instance.AddLayer(layer, 0);
+        }
+#endif
     }
 }

--- a/Source/Assets/TouchScript/Examples/_misc/Scripts/Runner.cs
+++ b/Source/Assets/TouchScript/Examples/_misc/Scripts/Runner.cs
@@ -4,7 +4,7 @@
 
 using UnityEngine;
 using TouchScript.Layers;
-#if UNITY_5_3
+#if UNITY_5_3 || UNITY_5_4
 using UnityEngine.SceneManagement;
 #endif
 
@@ -17,7 +17,7 @@ namespace TouchScript.Examples
 
         public void LoadNextLevel()
         {
-#if UNITY_5_3
+#if UNITY_5_3 || UNITY_5_4
             SceneManager.LoadScene((SceneManager.GetActiveScene().buildIndex + 1) % SceneManager.sceneCountInBuildSettings);
 #else
 			Application.LoadLevel((Application.loadedLevel + 1)%Application.levelCount);
@@ -34,7 +34,7 @@ namespace TouchScript.Examples
 
             layer = GetComponent<UILayer>();
 
-#if UNITY_5_3
+#if UNITY_5_3 || UNITY_5_4
             if (SceneManager.GetActiveScene().name == "Examples" && SceneManager.sceneCountInBuildSettings > 1)
 #else
 			if (Application.loadedLevelName == "Examples" && Application.levelCount > 1)

--- a/Source/Assets/TouchScript/Examples/_misc/Scripts/Runner.cs
+++ b/Source/Assets/TouchScript/Examples/_misc/Scripts/Runner.cs
@@ -4,7 +4,7 @@
 
 using UnityEngine;
 using TouchScript.Layers;
-#if UNITY_5_3 || UNITY_5_4
+#if UNITY_5_3_OR_NEWER
 using UnityEngine.SceneManagement;
 #endif
 
@@ -17,10 +17,10 @@ namespace TouchScript.Examples
 
         public void LoadNextLevel()
         {
-#if UNITY_5_3 || UNITY_5_4
+#if UNITY_5_3_OR_NEWER
             SceneManager.LoadScene((SceneManager.GetActiveScene().buildIndex + 1) % SceneManager.sceneCountInBuildSettings);
 #else
-			Application.LoadLevel((Application.loadedLevel + 1)%Application.levelCount);
+            Application.LoadLevel((Application.loadedLevel + 1)%Application.levelCount);
 #endif
         }
 
@@ -34,28 +34,27 @@ namespace TouchScript.Examples
 
             layer = GetComponent<UILayer>();
 
-#if UNITY_5_4
+#if UNITY_5_4_OR_NEWER
             SceneManager.sceneLoaded += LevelWasLoaded;
 #endif
 
-#if UNITY_5_3 || UNITY_5_4
+#if UNITY_5_3_OR_NEWER
             if (SceneManager.GetActiveScene().name == "Examples" && SceneManager.sceneCountInBuildSettings > 1)
 #else
-			if (Application.loadedLevelName == "Examples" && Application.levelCount > 1)
+            if (Application.loadedLevelName == "Examples" && Application.levelCount > 1)
 #endif
             {
                 LoadNextLevel();
             }
         }
 
-
-#if !UNITY_5_4
-        private void OnLevelWasLoaded(int value)
+#if UNITY_5_4_OR_NEWER
+        private void LevelWasLoaded(Scene scene, LoadSceneMode mode)
         {
             TouchManager.Instance.AddLayer(layer, 0);
         }
 #else
-        private void LevelWasLoaded(Scene scene, LoadSceneMode mode)
+        private void OnLevelWasLoaded(int value)
         {
             TouchManager.Instance.AddLayer(layer, 0);
         }

--- a/Source/Assets/TouchScript/Scripts/Devices/Display/GenericDisplayDevice.cs
+++ b/Source/Assets/TouchScript/Scripts/Devices/Display/GenericDisplayDevice.cs
@@ -46,10 +46,12 @@ namespace TouchScript.Devices.Display
                     case RuntimePlatform.OSXEditor:
                     case RuntimePlatform.OSXDashboardPlayer:
                     case RuntimePlatform.OSXPlayer:
+#if !UNITY_5_4
+                    case RuntimePlatform.WindowsWebPlayer:
                     case RuntimePlatform.OSXWebPlayer:
+#endif
                     case RuntimePlatform.WindowsEditor:
                     case RuntimePlatform.WindowsPlayer:
-                    case RuntimePlatform.WindowsWebPlayer:
                     case RuntimePlatform.LinuxPlayer:
                     {
                         var width = Mathf.Max(Screen.currentResolution.width, Screen.currentResolution.height);

--- a/Source/Assets/TouchScript/Scripts/Devices/Display/GenericDisplayDevice.cs
+++ b/Source/Assets/TouchScript/Scripts/Devices/Display/GenericDisplayDevice.cs
@@ -46,7 +46,7 @@ namespace TouchScript.Devices.Display
                     case RuntimePlatform.OSXEditor:
                     case RuntimePlatform.OSXDashboardPlayer:
                     case RuntimePlatform.OSXPlayer:
-#if !UNITY_5_4
+#if !UNITY_5_4_OR_NEWER
                     case RuntimePlatform.WindowsWebPlayer:
                     case RuntimePlatform.OSXWebPlayer:
 #endif

--- a/Source/Assets/TouchScript/Scripts/TouchManagerInstance.cs
+++ b/Source/Assets/TouchScript/Scripts/TouchManagerInstance.cs
@@ -15,6 +15,10 @@ using TouchScript.Utils.Debug;
 #endif
 using UnityEngine;
 
+#if UNITY_5_4
+using UnityEngine.SceneManagement;
+#endif
+
 namespace TouchScript
 {
     /// <summary>
@@ -488,6 +492,10 @@ namespace TouchScript
                 return;
             }
 
+#if UNITY_5_4
+            SceneManager.sceneLoaded += LevelWasLoaded;
+#endif
+
             gameObject.hideFlags = HideFlags.HideInHierarchy;
             DontDestroyOnLoad(gameObject);
 
@@ -504,11 +512,19 @@ namespace TouchScript
 #endif
         }
 
+#if !UNITY_5_4
         private void OnLevelWasLoaded(int value)
         {
             StopAllCoroutines();
             StartCoroutine(lateAwake());
         }
+#else
+        private void LevelWasLoaded(Scene scene, LoadSceneMode mode)
+        {
+            StopAllCoroutines();
+            StartCoroutine(lateAwake());
+        }
+#endif
 
         private IEnumerator lateAwake()
         {

--- a/Source/Assets/TouchScript/Scripts/TouchManagerInstance.cs
+++ b/Source/Assets/TouchScript/Scripts/TouchManagerInstance.cs
@@ -15,7 +15,7 @@ using TouchScript.Utils.Debug;
 #endif
 using UnityEngine;
 
-#if UNITY_5_4
+#if UNITY_5_4_OR_NEWER
 using UnityEngine.SceneManagement;
 #endif
 
@@ -492,7 +492,7 @@ namespace TouchScript
                 return;
             }
 
-#if UNITY_5_4
+#if UNITY_5_4_OR_NEWER
             SceneManager.sceneLoaded += LevelWasLoaded;
 #endif
 
@@ -512,14 +512,14 @@ namespace TouchScript
 #endif
         }
 
-#if !UNITY_5_4
-        private void OnLevelWasLoaded(int value)
+#if UNITY_5_4_OR_NEWER
+        private void LevelWasLoaded(Scene scene, LoadSceneMode mode)
         {
             StopAllCoroutines();
             StartCoroutine(lateAwake());
         }
 #else
-        private void LevelWasLoaded(Scene scene, LoadSceneMode mode)
+        private void OnLevelWasLoaded(int value)
         {
             StopAllCoroutines();
             StartCoroutine(lateAwake());


### PR DESCRIPTION
This PR removes the deprecation warnings present when using TouchScript in a Unity 5.4 project.

