### PR TITLE
Added ExclusiveObjectLocks option in TouchManager to lock all input on one object.

### DIFF
--- a/Source/Assets/TouchScript/Editor/TouchManagerEditor.cs
+++ b/Source/Assets/TouchScript/Editor/TouchManagerEditor.cs
@@ -19,6 +19,7 @@ namespace TouchScript.Editor
         private static readonly GUIContent DISPLAY_DEVICE = new GUIContent("Display Device", "Display device properties where such parameters as target DPI are stored.");
         private static readonly GUIContent CREATE_CAMERA_LAYER = new GUIContent("Create Camera Layer", "Indicates if TouchScript should create a CameraLayer for you if no layers present in a scene. This is usually a desired behavior but sometimes you would want to turn this off if you are using TouchScript only to get touch input from some device.");
         private static readonly GUIContent CREATE_STANDARD_INPUT = new GUIContent("Create Standard Input", "");
+        private static readonly GUIContent EXCLUSIVE_OBJECT_LOCKS = new GUIContent("Exclusive Object Locks", "Only one object can recieve touch in one moment.");
         private static readonly GUIContent USE_SEND_MESSAGE = new GUIContent("Use SendMessage", "If you use UnityScript or prefer using Unity Messages you can turn them on with this option.");
         private static readonly GUIContent SEND_MESSAGE_TARGET = new GUIContent("SendMessage Target", "The GameObject target of Unity Messages. If null, host GameObject is used.");
         private static readonly GUIContent SEND_MESSAGE_EVENTS = new GUIContent("SendMessage Events", "Which events should be sent as Unity Messages.");
@@ -26,7 +27,7 @@ namespace TouchScript.Editor
 
         private TouchManager instance;
         private ReorderableList layersList;
-        private SerializedProperty layers, displayDevice, shouldCreateCameraLayer, shouldCreateStandardInput, useSendMessage, sendMessageTarget, sendMessageEvents;
+        private SerializedProperty layers, displayDevice, shouldCreateCameraLayer, shouldCreateStandardInput, exclusiveObjectLocks, useSendMessage, sendMessageTarget, sendMessageEvents;
 
         private void OnEnable()
         {
@@ -35,6 +36,7 @@ namespace TouchScript.Editor
             displayDevice = serializedObject.FindProperty("displayDevice");
             shouldCreateCameraLayer = serializedObject.FindProperty("shouldCreateCameraLayer");
             shouldCreateStandardInput = serializedObject.FindProperty("shouldCreateStandardInput");
+            exclusiveObjectLocks = serializedObject.FindProperty("exclusiveObjectLocks");
             useSendMessage = serializedObject.FindProperty("useSendMessage");
             sendMessageTarget = serializedObject.FindProperty("sendMessageTarget");
             sendMessageEvents = serializedObject.FindProperty("sendMessageEvents");
@@ -77,6 +79,7 @@ namespace TouchScript.Editor
             if (Application.isPlaying) GUI.enabled = false;
             EditorGUILayout.PropertyField(shouldCreateCameraLayer, CREATE_CAMERA_LAYER);
             EditorGUILayout.PropertyField(shouldCreateStandardInput, CREATE_STANDARD_INPUT);
+            EditorGUILayout.PropertyField(exclusiveObjectLocks, EXCLUSIVE_OBJECT_LOCKS);
             GUI.enabled = true;
 
             EditorGUIUtility.labelWidth = 160;

--- a/Source/Assets/TouchScript/Scripts/Gestures/Gesture.cs
+++ b/Source/Assets/TouchScript/Scripts/Gestures/Gesture.cs
@@ -696,6 +696,10 @@ namespace TouchScript.Gestures
                 INTERNAL_RemoveFriendlyGesture(copy[i]);
             }
             RequireGestureToFail = null;
+
+            // remove from exclusive locks
+            if (gestureManagerInstance != null)
+                gestureManagerInstance.RemoveExclusiveLock(this);
         }
 
         #endregion

--- a/Source/Assets/TouchScript/Scripts/ITouchManager.cs
+++ b/Source/Assets/TouchScript/Scripts/ITouchManager.cs
@@ -97,6 +97,12 @@ namespace TouchScript
         bool ShouldCreateStandardInput { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating can more than one object recieved touches at tne same time or not.
+        /// </summary>
+        /// <value> <c>true</c> if only one object can recieve touches at the same time; otherwise, <c>false</c>. </value>
+        bool ExclusiveObjectLocks { get; set; }
+
+        /// <summary>
         /// Gets the list of <see cref="TouchLayer"/>.
         /// </summary>
         /// <value>A sorted list of currently active touch layers.</value>

--- a/Source/Assets/TouchScript/Scripts/TouchManager.cs
+++ b/Source/Assets/TouchScript/Scripts/TouchManager.cs
@@ -192,6 +192,21 @@ namespace TouchScript
         }
 
         /// <summary>
+        /// Gets or sets a value indicating can more than one object recieved touches at tne same time or not.
+        /// </summary>
+        /// <value> <c>true</c> if only one object can recieve touches at the same time; otherwise, <c>false</c>. </value>
+        public bool ExclusiveObjectLocks
+        {
+            get { return exclusiveObjectLocks; }
+            set
+            {
+                exclusiveObjectLocks = value;
+                if (Instance != null)
+                    Instance.ExclusiveObjectLocks = value;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating whether Unity messages are sent when <see cref="ITouchManager"/> dispatches events.
         /// </summary>
         /// <value><c>true</c> if Unity messages are used; otherwise, <c>false</c>.</value>
@@ -267,6 +282,10 @@ namespace TouchScript
 
         [SerializeField]
         [ToggleLeft]
+        private bool exclusiveObjectLocks = false;
+
+        [SerializeField]
+        [ToggleLeft]
         private bool useSendMessage = false;
 
         [SerializeField]
@@ -290,6 +309,7 @@ namespace TouchScript
             Instance.DisplayDevice = displayDevice as IDisplayDevice;
             Instance.ShouldCreateCameraLayer = ShouldCreateCameraLayer;
             Instance.ShouldCreateStandardInput = ShouldCreateStandardInput;
+            Instance.ExclusiveObjectLocks = ExclusiveObjectLocks;
             for (var i = 0; i < layers.Count; i++)
             {
                 Instance.AddLayer(layers[i], i);

--- a/Source/Assets/TouchScript/Scripts/TouchManagerInstance.cs
+++ b/Source/Assets/TouchScript/Scripts/TouchManagerInstance.cs
@@ -152,6 +152,13 @@ namespace TouchScript
         }
 
         /// <inheritdoc />
+        public bool ExclusiveObjectLocks
+        {
+            get { return exclusiveObjectLocks; }
+            set { exclusiveObjectLocks = value; }
+        }
+
+        /// <inheritdoc />
         public IList<TouchLayer> Layers
         {
             get { return new List<TouchLayer>(layers); }
@@ -189,6 +196,7 @@ namespace TouchScript
         private static TouchManagerInstance instance;
         private bool shouldCreateCameraLayer = true;
         private bool shouldCreateStandardInput = true;
+        private bool exclusiveObjectLocks = false;
 
         private IDisplayDevice displayDevice;
         private float dpi = 96;


### PR DESCRIPTION
For example you have a map that can rotate, scale etc. and a bunch of buttons. In this case you need a multitouch support for your map but when you scale the map you doesn't want to press any button accidentally. So this option provides that.
