### PR TITLE
Add optional non-simultaneous transform restriction

### DIFF
--- a/Source/Assets/TouchScript/Editor/Gestures/TransformGestures/Base/OnePointTransformGestureBaseEditor.cs
+++ b/Source/Assets/TouchScript/Editor/Gestures/TransformGestures/Base/OnePointTransformGestureBaseEditor.cs
@@ -49,7 +49,8 @@ namespace TouchScript.Editor.Gestures.TransformGestures.Base
             type.intValue = newType;
             EditorGUI.indentLevel++;
 
-            EditorGUIUtility.labelWidth = 160;
+            EditorGUIUtility.labelWidth = 200;
+            EditorGUILayout.PropertyField(simultaneousTransform, TEXT_SIMULTANEOUS_TRANSFORM);
             EditorGUILayout.PropertyField(screenTransformThreshold, TEXT_SCREEN_TRANSFORM_THRESHOLD);
 
             base.drawGeneral();

--- a/Source/Assets/TouchScript/Editor/Gestures/TransformGestures/Base/TransformGestureBaseEditor.cs
+++ b/Source/Assets/TouchScript/Editor/Gestures/TransformGestures/Base/TransformGestureBaseEditor.cs
@@ -17,6 +17,7 @@ namespace TouchScript.Editor.Gestures.TransformGestures.Base
         public static readonly GUIContent TEXT_TYPE_TRANSLATION = new GUIContent("Translation", "Dragging with one ore more fingers.");
         public static readonly GUIContent TEXT_TYPE_ROTATION = new GUIContent("Rotation", "Rotating with two or more fingers.");
         public static readonly GUIContent TEXT_TYPE_SCALING = new GUIContent("Scaling", "Scaling with two or more fingers.");
+        public static readonly GUIContent TEXT_SIMULTANEOUS_TRANSFORM = new GUIContent("Simultaneous Transformations", "Whether multiple types of transformations can occur each time this gesture is used.");
         public static readonly GUIContent TEXT_MIN_SCREEN_POINTS_DISTANCE = new GUIContent("Min Points Distance (cm)", "Minimum distance between two pointers (clusters) in cm to consider this gesture started. Used to prevent fake pointers spawned near real ones on cheap multitouch hardware to mess everything up.");
         public static readonly GUIContent TEXT_SCREEN_TRANSFORM_THRESHOLD = new GUIContent("Movement Threshold (cm)", "Minimum distance in cm pointers must move for the gesture to begin.");
 
@@ -27,7 +28,7 @@ namespace TouchScript.Editor.Gestures.TransformGestures.Base
         public static readonly GUIContent TEXT_PROJECTION_NORMAL = new GUIContent("Projection Normal", "Normal of the plane in 3d space where pointers' positions are projected.");
 
 
-        protected SerializedProperty type, minScreenPointsDistance, screenTransformThreshold;
+        protected SerializedProperty type, simultaneousTransform, minScreenPointsDistance, screenTransformThreshold;
         protected SerializedProperty OnTransformStart, OnTransform, OnTransformComplete;
 
         public SerializedProperty projection, projectionPlaneNormal;
@@ -41,6 +42,7 @@ namespace TouchScript.Editor.Gestures.TransformGestures.Base
         protected override void OnEnable()
         {
             type = serializedObject.FindProperty("type");
+            simultaneousTransform = serializedObject.FindProperty("simultaneousTransforms");
             minScreenPointsDistance = serializedObject.FindProperty("minScreenPointsDistance");
             screenTransformThreshold = serializedObject.FindProperty("screenTransformThreshold");
             OnTransformStart = serializedObject.FindProperty("OnTransformStart");

--- a/Source/Assets/TouchScript/Editor/Gestures/TransformGestures/Base/TwoPointTransformGestureBaseEditor.cs
+++ b/Source/Assets/TouchScript/Editor/Gestures/TransformGestures/Base/TwoPointTransformGestureBaseEditor.cs
@@ -60,7 +60,8 @@ namespace TouchScript.Editor.Gestures.TransformGestures.Base
 
             EditorGUI.indentLevel++;
 
-            EditorGUIUtility.labelWidth = 160;
+            EditorGUIUtility.labelWidth = 200;
+            EditorGUILayout.PropertyField(simultaneousTransform, TEXT_SIMULTANEOUS_TRANSFORM);
             EditorGUILayout.PropertyField(minScreenPointsDistance, TEXT_MIN_SCREEN_POINTS_DISTANCE);
             EditorGUILayout.PropertyField(screenTransformThreshold, TEXT_SCREEN_TRANSFORM_THRESHOLD);
 

--- a/Source/Assets/TouchScript/Scripts/Gestures/TransformGestures/Base/OnePointTrasformGestureBase.cs
+++ b/Source/Assets/TouchScript/Scripts/Gestures/TransformGestures/Base/OnePointTrasformGestureBase.cs
@@ -174,6 +174,22 @@ namespace TouchScript.Gestures.TransformGestures.Base
                 }
             }
 
+            if (!simultaneousTransforms)
+            {
+                if (isTransforming)
+                {
+                    var fixedType = getIndicatedType(screenCenter, oldScreenPos, newScreenPos, projectionParams);
+                    transformLock.TrySetValue(fixedType);
+                }
+
+                if (transformLock.Locked)
+                {
+                    var singleType = transformLock.Value;
+                    if (singleType != TransformGesture.TransformType.Rotation) dR = 0;
+                    if (singleType != TransformGesture.TransformType.Scaling) dS = 1;
+                }
+            }
+
             if (dR != 0) transformMask |= TransformGesture.TransformType.Rotation;
             if (dS != 1) transformMask |= TransformGesture.TransformType.Scaling;
 
@@ -239,6 +255,25 @@ namespace TouchScript.Gestures.TransformGestures.Base
                                 ProjectionParams projectionParams)
         {
             return 1;
+        }
+
+        /// <summary>
+        /// Return the <see cref="TransformGesture.TransformType"/> indicated by the finger's movement.
+        /// </summary>
+        /// <param name="center"> Center screen position. </param>
+        /// <param name="oldScreenPos"> Pointer old screen position. </param>
+        /// <param name="newScreenPos"> Pointer new screen position. </param>
+        /// <param name="projectionParams"> Layer projection parameters. </param>
+        /// <returns> TransformType indicated by the movement of the pointer. </returns>
+        protected virtual TransformGesture.TransformType getIndicatedType(Vector2 screenCenter, Vector2 oldScreenPos, Vector2 newScreenPos, ProjectionParams projectionParams)
+        {
+            var centerLine = oldScreenPos - screenCenter;
+            var pointerDelta = newScreenPos - oldScreenPos;
+
+            if (TwoD.IsPerpendicular(centerLine, pointerDelta))
+                return TransformGesture.TransformType.Rotation;
+            else
+                return TransformGesture.TransformType.Scaling;
         }
 
         /// <summary>

--- a/Source/Assets/TouchScript/Scripts/Gestures/TransformGestures/Base/OnePointTrasformGestureBase.cs
+++ b/Source/Assets/TouchScript/Scripts/Gestures/TransformGestures/Base/OnePointTrasformGestureBase.cs
@@ -180,13 +180,11 @@ namespace TouchScript.Gestures.TransformGestures.Base
                 {
                     var fixedType = getIndicatedType(screenCenter, oldScreenPos, newScreenPos, projectionParams);
                     transformLock.TrySetValue(fixedType);
-                }
 
-                if (transformLock.Locked)
-                {
                     var singleType = transformLock.Value;
                     if (singleType != TransformGesture.TransformType.Rotation) dR = 0;
                     if (singleType != TransformGesture.TransformType.Scaling) dS = 1;
+                    if (singleType != 0 && type.HasFlag(singleType)) transformLock.SetLock();
                 }
             }
 

--- a/Source/Assets/TouchScript/Scripts/Gestures/TransformGestures/Base/TransformGestureBase.cs
+++ b/Source/Assets/TouchScript/Scripts/Gestures/TransformGestures/Base/TransformGestureBase.cs
@@ -101,6 +101,15 @@ namespace TouchScript.Gestures.TransformGestures.Base
         }
 
         /// <summary>
+        /// Gets or sets whether multiple types of transformations can occur each time this gesture is used.
+        /// </summary>
+        public bool SimultaneousTransforms
+        {
+            get { return simultaneousTransforms; }
+            set { simultaneousTransforms = value; }
+        }
+
+        /// <summary>
         /// Gets or sets minimum distance in cm for pointers to move for gesture to begin. 
         /// </summary>
         /// <value> Minimum value in cm user must move their fingers to start this gesture. </value>
@@ -164,6 +173,11 @@ namespace TouchScript.Gestures.TransformGestures.Base
         protected TransformGesture.TransformType transformMask;
 
         /// <summary>
+        /// The single transform type this gesture is restricted to. <see cref="SimultaneousTransforms"/>
+        /// </summary>
+        protected Lock<TransformGesture.TransformType> transformLock = new Lock<TransformGesture.TransformType>();
+
+        /// <summary>
         /// Calculated delta position.
         /// </summary>
         protected Vector3 deltaPosition;
@@ -205,6 +219,12 @@ namespace TouchScript.Gestures.TransformGestures.Base
         [SerializeField]
         protected TransformGesture.TransformType type = TransformGesture.TransformType.Translation | TransformGesture.TransformType.Scaling |
                                                         TransformGesture.TransformType.Rotation;
+
+        /// <summary>
+        /// Whether multiple types of transformations can occur each time this gesture is used.
+        /// </summary>
+        [SerializeField]
+        protected bool simultaneousTransforms = true;
 
         [SerializeField]
         private float screenTransformThreshold = 0.1f;
@@ -262,6 +282,7 @@ namespace TouchScript.Gestures.TransformGestures.Base
                 {
                     case GestureState.Began:
                     case GestureState.Changed:
+                        transformLock.Unlock();
                         setState(GestureState.Ended);
                         break;
                 }
@@ -282,6 +303,7 @@ namespace TouchScript.Gestures.TransformGestures.Base
                 {
                     case GestureState.Began:
                     case GestureState.Changed:
+                        transformLock.Unlock();
                         setState(GestureState.Ended);
                         break;
                     case GestureState.Possible:

--- a/Source/Assets/TouchScript/Scripts/Gestures/TransformGestures/Base/TransformGestureBase.cs
+++ b/Source/Assets/TouchScript/Scripts/Gestures/TransformGestures/Base/TransformGestureBase.cs
@@ -282,7 +282,7 @@ namespace TouchScript.Gestures.TransformGestures.Base
                 {
                     case GestureState.Began:
                     case GestureState.Changed:
-                        transformLock.Unlock();
+                        transformLock.ClearLock();
                         setState(GestureState.Ended);
                         break;
                 }
@@ -303,7 +303,7 @@ namespace TouchScript.Gestures.TransformGestures.Base
                 {
                     case GestureState.Began:
                     case GestureState.Changed:
-                        transformLock.Unlock();
+                        transformLock.ClearLock();
                         setState(GestureState.Ended);
                         break;
                     case GestureState.Possible:

--- a/Source/Assets/TouchScript/Scripts/Gestures/TransformGestures/Base/TwoPointTransformGestureBase.cs
+++ b/Source/Assets/TouchScript/Scripts/Gestures/TransformGestures/Base/TwoPointTransformGestureBase.cs
@@ -235,12 +235,13 @@ namespace TouchScript.Gestures.TransformGestures.Base
                 }
             }
 
-            if (!simultaneousTransforms && transformLock.Locked)
+            if (!simultaneousTransforms && isTransforming)
             {
                 var singleType = transformLock.Value;
                 if (singleType != TransformGesture.TransformType.Translation) dP = Vector3.zero;
                 if (singleType != TransformGesture.TransformType.Rotation) dR = 0;
                 if (singleType != TransformGesture.TransformType.Scaling) dS = 1;
+                if (singleType != 0 && type.HasFlag(singleType)) transformLock.SetLock();
             }
 
             if (dP != Vector3.zero) transformMask |= TransformGesture.TransformType.Translation;

--- a/Source/Assets/TouchScript/Scripts/Utils/Geom/TwoD.cs
+++ b/Source/Assets/TouchScript/Scripts/Utils/Geom/TwoD.cs
@@ -58,5 +58,17 @@ namespace TouchScript.Utils.Geom
             var sin = Mathf.Sin(rad);
             return new Vector2(point.x * cos - point.y * sin, point.x * sin + point.y * cos);
         }
+
+        /// <summary>
+        /// Determines if two lines are approximately perpendicular.
+        /// </summary>
+        /// <param name="line1">Line to check.</param>
+        /// <param name="line2">Line to check.</param>
+        /// <returns> <c>true</c> if both lines are approximately perpendicular; <c>false</c> otherwise.</returns>
+        public static bool IsPerpendicular(Vector2 line1, Vector2 line2)
+        {
+            var deg = Vector2.Angle(line1, line2);
+            return (45 < deg) && (deg < 135);
+        }
     }
 }

--- a/Source/Assets/TouchScript/Scripts/Utils/Lock.cs
+++ b/Source/Assets/TouchScript/Scripts/Utils/Lock.cs
@@ -10,18 +10,22 @@
         public bool Locked { get; private set; }
 
         /// <summary>
-        /// If unlocked, set the value and lock it.
+        /// If unlocked, set the value.
         /// </summary>
         public void TrySetValue(T value)
         {
             if (!Locked)
             {
-                Locked = true;
                 Value = value;
             }
         }
 
-        public void Unlock()
+        public void SetLock()
+        {
+            Locked = true;
+        }
+
+        public void ClearLock()
         {
             Locked = false;
         }

--- a/Source/Assets/TouchScript/Scripts/Utils/Lock.cs
+++ b/Source/Assets/TouchScript/Scripts/Utils/Lock.cs
@@ -1,0 +1,29 @@
+﻿namespace TouchScript.Utils
+{
+    /// <summary>
+    /// Holds a value which can only be changed when unlocked.
+    /// </summary>
+    public class Lock<T>
+    {
+        public T Value { get; private set; }
+
+        public bool Locked { get; private set; }
+
+        /// <summary>
+        /// If unlocked, set the value and lock it.
+        /// </summary>
+        public void TrySetValue(T value)
+        {
+            if (!Locked)
+            {
+                Locked = true;
+                Value = value;
+            }
+        }
+
+        public void Unlock()
+        {
+            Locked = false;
+        }
+    }
+}


### PR DESCRIPTION
### Why?
I added this option because controlling a camera's translation, rotation, **and** scaling at the same time was too fiddly. For example, rotating would also zoom the camera. This way, a person can rotate without worrying about zooming, zoom without translating, etc.

### What?
Can now disallow multiple types of transformations to occur each time a
gesture is used.

For example, when a gesture is used to rotate it cannot scale or
translate. Once the gesture ends it is reset and can again be used for
any type of transformation.

There is a checkbox in the inspector to select this option. It is under
Advanced > General > Simultaneous Transforms.

It works for both One- and Two- Point transformations, including
two-finger translation, 2+ finger transformations, and clustered
transforms.

### How?
Here's a picture explaining how I determine which gesture to lock into:

![nonsimultaneous transform logic](https://user-images.githubusercontent.com/11803661/30625521-99ea5d4c-9d78-11e7-89a7-c3b1564c93fd.jpg)
