### PR TITLE
TouchScript input module fix

### DIFF
--- a/Source/Assets/Test.meta
+++ b/Source/Assets/Test.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: 7e1fcc64fde35914b886872755292f44
-folderAsset: yes
-timeCreated: 1490462516
-licenseType: Pro
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Source/Assets/TouchScript/Editor/Gestures/GestureEditor.cs
+++ b/Source/Assets/TouchScript/Editor/Gestures/GestureEditor.cs
@@ -223,6 +223,8 @@ namespace TouchScript.Editor.Gestures
                 EditorGUILayout.LabelField("Min: " + (int) minPointersFloat + ", Max: " + (int) maxPointersFloat);
                 EditorGUILayout.MinMaxSlider(ref minPointersFloat, ref maxPointersFloat, 0, 10, GUILayout.MaxWidth(150));
                 EditorGUI.indentLevel--;
+                minPointers.intValue = (int) minPointersFloat;
+                maxPointers.intValue = (int) maxPointersFloat;
             }
             else
             {
@@ -230,11 +232,10 @@ namespace TouchScript.Editor.Gestures
                 {
                     minPointersFloat = 0;
                     maxPointersFloat = 0;
+                    minPointers.intValue = (int) minPointersFloat;
+                    maxPointers.intValue = (int) maxPointersFloat;
                 }
             }
-
-            minPointers.intValue = (int) minPointersFloat;
-            maxPointers.intValue = (int) maxPointersFloat;
         }
 
         protected virtual void drawFriendlyGestures()

--- a/Source/Assets/TouchScript/Editor/Layers/FullscreenLayerEditor.cs
+++ b/Source/Assets/TouchScript/Editor/Layers/FullscreenLayerEditor.cs
@@ -12,8 +12,10 @@ namespace TouchScript.Editor.Layers
     [CustomEditor(typeof(FullscreenLayer))]
     internal sealed class FullscreenLayerEditor : UnityEditor.Editor
     {
+        public static readonly GUIContent TEXT_NAME = new GUIContent("Name", "Layer name.");
         public static readonly GUIContent TEXT_HELP = new GUIContent("This component receives all pointers which were not caught by other layers. It sets poitners' Target property to itself, so all fullscreen gestures must be attached to the same GameObject as FullscreenGesture.");
 
+        private SerializedProperty layerName;
         private SerializedProperty type, camera;
         private FullscreenLayer instance;
 
@@ -21,14 +23,20 @@ namespace TouchScript.Editor.Layers
         {
             instance = target as FullscreenLayer;
 
+            layerName = serializedObject.FindProperty("layerName");
             type = serializedObject.FindProperty("type");
             camera = serializedObject.FindProperty("_camera");
         }
 
         public override void OnInspectorGUI()
         {
-            serializedObject.Update();
+#if UNITY_5_6_OR_NEWER
+            serializedObject.UpdateIfRequiredOrScript();
+#else
+            serializedObject.UpdateIfDirtyOrScript();
+#endif
 
+            EditorGUILayout.PropertyField(layerName, TEXT_NAME);
             EditorGUI.BeginChangeCheck();
             EditorGUILayout.PropertyField(type);
             if (EditorGUI.EndChangeCheck())
@@ -47,6 +55,8 @@ namespace TouchScript.Editor.Layers
             }
 
             EditorGUILayout.LabelField(TEXT_HELP, GUIElements.HelpBox);
+
+            serializedObject.ApplyModifiedProperties();
         }
     }
 }

--- a/Source/Assets/TouchScript/Editor/Layers/StandardLayerEditor.cs
+++ b/Source/Assets/TouchScript/Editor/Layers/StandardLayerEditor.cs
@@ -15,6 +15,7 @@ namespace TouchScript.Editor.Layers
         public static readonly GUIContent TEXT_ADVANCED_HEADER = new GUIContent("Advanced", "Advanced properties.");
         public static readonly GUIContent TEXT_HIT_HEADER = new GUIContent("Hit test options", "Options which control what types of objects this layer should search under pointers.");
 
+        public static readonly GUIContent TEXT_NAME = new GUIContent("Name", "Layer name.");
         public static readonly GUIContent TEXT_3D_OBJECTS = new GUIContent("Hit 3D Objects", "Layer should raycast 3D objects.");
         public static readonly GUIContent TEXT_2D_OBJECTS = new GUIContent("Hit 2D Objects", "Layer should raycast 2D objects.");
         public static readonly GUIContent TEXT_WORLD_UI = new GUIContent("Hit World UI", "Layer should raycast World Space UI.");
@@ -25,6 +26,7 @@ namespace TouchScript.Editor.Layers
         public static readonly GUIContent TEXT_HELP = new GUIContent("This component assigns target GameObjects in the scene for pressed pointers.");
 
         private SerializedProperty advancedProps, hitProps;
+        private SerializedProperty layerName;
         private SerializedProperty basicEditor;
         private SerializedProperty hit3DObjects;
         private SerializedProperty hit2DObjects;
@@ -39,6 +41,7 @@ namespace TouchScript.Editor.Layers
 
             advancedProps = serializedObject.FindProperty("advancedProps");
             hitProps = serializedObject.FindProperty("hitProps");
+            layerName = serializedObject.FindProperty("layerName");
             basicEditor = serializedObject.FindProperty("basicEditor");
             hit3DObjects = serializedObject.FindProperty("hit3DObjects");
             hit2DObjects = serializedObject.FindProperty("hit2DObjects");
@@ -70,6 +73,7 @@ namespace TouchScript.Editor.Layers
             }
             else
             {
+                drawName();
                 drawHit();
                 drawAdvanced();
             }
@@ -86,6 +90,11 @@ namespace TouchScript.Editor.Layers
                 doDrawHit();
                 EditorGUI.indentLevel--;
             }
+        }
+
+        protected virtual void drawName()
+        {
+            EditorGUILayout.PropertyField(layerName, TEXT_NAME);
         }
 
         protected virtual void doDrawHit()

--- a/Source/Assets/TouchScript/Editor/TouchManagerEditor.cs
+++ b/Source/Assets/TouchScript/Editor/TouchManagerEditor.cs
@@ -236,12 +236,16 @@ namespace TouchScript.Editor
             if (Application.isPlaying)
             {
                 layers.arraySize = 0;
-                LayerManager.Instance.ForEach((l) =>
-                            {
-                                layers.arraySize++;
-                                layers.GetArrayElementAtIndex(layers.arraySize - 1).objectReferenceValue = l;
-                                return true;
-                            });
+                var layerManager = LayerManager.Instance;
+                if (layerManager != null) 
+                {
+                    LayerManager.Instance.ForEach((l) =>
+                                {
+                                    layers.arraySize++;
+                                    layers.GetArrayElementAtIndex(layers.arraySize - 1).objectReferenceValue = l;
+                                    return true;
+                                });
+                }
             }
             else
             {

--- a/Source/Assets/TouchScript/Editor/TouchManagerEditor.cs
+++ b/Source/Assets/TouchScript/Editor/TouchManagerEditor.cs
@@ -207,7 +207,11 @@ namespace TouchScript.Editor
                     var label = EditorGUI.BeginProperty(r, TEXT_SEND_MESSAGE_EVENTS, sendMessageEvents);
                     EditorGUI.BeginChangeCheck();
                     r = EditorGUI.PrefixLabel(r, label);
+#if UNITY_2017_3_OR_NEWER
+                    var sMask = (TouchManager.MessageType) EditorGUI.EnumFlagsField(r, instance.SendMessageEvents);
+#else
                     var sMask = (TouchManager.MessageType) EditorGUI.EnumMaskField(r, instance.SendMessageEvents);
+#endif
                     if (EditorGUI.EndChangeCheck())
                     {
                         instance.SendMessageEvents = sMask;

--- a/Source/Assets/TouchScript/Editor/Utils/PropertyDrawers/NullToggleDrawer.cs
+++ b/Source/Assets/TouchScript/Editor/Utils/PropertyDrawers/NullToggleDrawer.cs
@@ -26,20 +26,23 @@ namespace TouchScript.Editor.Utils.PropertyDrawers
             updateExpanded(property);
 
             EditorGUIUtility.labelWidth = 60;
-            Begin(position, property, label);
+            bool expandedChanged = Begin(position, property, label);
             if (expanded == false)
             {
-                switch (property.propertyType)
+                if (expandedChanged)
                 {
-                    case SerializedPropertyType.ObjectReference:
-                        property.objectReferenceValue = (Object) getNullValue(property);
-                        break;
-                    case SerializedPropertyType.Integer:
-                        property.intValue = (int) getNullValue(property);
-                        break;
-                    case SerializedPropertyType.Float:
-                        property.floatValue = (float) getNullValue(property);
-                        break;
+                    switch (property.propertyType)
+                    {
+                        case SerializedPropertyType.ObjectReference:
+                            property.objectReferenceValue = (Object) getNullValue(property);
+                            break;
+                        case SerializedPropertyType.Integer:
+                            property.intValue = (int) getNullValue(property);
+                            break;
+                        case SerializedPropertyType.Float:
+                            property.floatValue = (float) getNullValue(property);
+                            break;
+                    }
                 }
             }
             else
@@ -134,13 +137,15 @@ namespace TouchScript.Editor.Utils.PropertyDrawers
             //        }
         }
 
-        private void Begin(Rect position, SerializedProperty property, GUIContent label)
+        private bool Begin(Rect position, SerializedProperty property, GUIContent label)
         {
             label = EditorGUI.BeginProperty(position, label, property);
             label.text = " " + label.text;
             position.height = 16;
             EditorGUIUtility.labelWidth = 180;
+            EditorGUI.BeginChangeCheck();
             expanded = EditorGUI.ToggleLeft(position, label, expanded == true);
+            return EditorGUI.EndChangeCheck();
         }
 
         private void End()

--- a/Source/Assets/TouchScript/Editor/Utils/PropertyDrawers/NullToggleDrawer.cs
+++ b/Source/Assets/TouchScript/Editor/Utils/PropertyDrawers/NullToggleDrawer.cs
@@ -11,28 +11,26 @@ namespace TouchScript.Editor.Utils.PropertyDrawers
     [CustomPropertyDrawer(typeof(NullToggleAttribute))]
     internal sealed class NullToggleDrawer : PropertyDrawer
     {
-        class SPUD
+        private class SharedData
         {
             internal bool expanded = false;
         }
 
-        private SPUD expanded = null;
-
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
         {
-            var spud = updateExpanded(property);
-            if (spud.expanded == false) return 16;
+            var data = updateExpanded(property);
+            if (data.expanded == false) return 16;
             if (property.propertyType == SerializedPropertyType.ObjectReference && property.objectReferenceValue != null) return 16 * 3 + 2 * 2;
             return 16 * 2 + 2;
         }
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
-            var spud = updateExpanded(property);
+            var data = updateExpanded(property);
 
             EditorGUIUtility.labelWidth = 60;
-            bool expandedChanged = Begin(spud, position, property, label);
-            if (spud.expanded == false)
+            bool expandedChanged = Begin(data, position, property, label);
+            if (data.expanded == false)
             {
                 if (expandedChanged)
                 {
@@ -78,78 +76,16 @@ namespace TouchScript.Editor.Utils.PropertyDrawers
                 }
             }
             End();
-
-
-            //    case SerializedPropertyType.Float:
-            //        {
-            //            EditorGUI.BeginChangeCheck();
-            //            float floatValue = EditorGUI.FloatField(position, label, property.floatValue);
-            //            if (EditorGUI.EndChangeCheck())
-            //            {
-            //                property.floatValue = floatValue;
-            //            }
-            //            break;
-            //        }
-            //    case SerializedPropertyType.String:
-            //        {
-            //            EditorGUI.BeginChangeCheck();
-            //            string stringValue = EditorGUI.TextField(position, label, property.stringValue);
-            //            if (EditorGUI.EndChangeCheck())
-            //            {
-            //                property.stringValue = stringValue;
-            //            }
-            //            break;
-            //        }
-            //    case SerializedPropertyType.Color:
-            //        {
-            //            EditorGUI.BeginChangeCheck();
-            //            Color colorValue = EditorGUI.ColorField(position, label, property.colorValue);
-            //            if (EditorGUI.EndChangeCheck())
-            //            {
-            //                property.colorValue = colorValue;
-            //            }
-            //            break;
-            //        }
-            //    case SerializedPropertyType.LayerMask:
-            //        EditorGUI.LayerMaskField(position, property, label);
-            //        break;
-            //    case SerializedPropertyType.Enum:
-            //        EditorGUI.Popup(position, property, label);
-            //        break;
-            //    case SerializedPropertyType.Vector2:
-            //        EditorGUI.Vector2Field(position, property, label);
-            //        break;
-            //    case SerializedPropertyType.Vector3:
-            //        EditorGUI.Vector3Field(position, property, label);
-            //        break;
-            //    case SerializedPropertyType.Rect:
-            //        EditorGUI.RectField(position, property, label);
-            //        break;
-            //    case SerializedPropertyType.AnimationCurve:
-            //        {
-            //            int controlID = GUIUtility.GetControlID(EditorGUI.s_CurveHash, EditorGUIUtility.native, position);
-            //            EditorGUI.DoCurveField(EditorGUI.PrefixLabel(position, controlID, label), controlID, null, EditorGUI.kCurveColor, default(Rect), property);
-            //            break;
-            //        }
-            //    case SerializedPropertyType.Bounds:
-            //        EditorGUI.BoundsField(position, property, label);
-            //        break;
-            //    case SerializedPropertyType.Gradient:
-            //        {
-            //            int controlID2 = GUIUtility.GetControlID(EditorGUI.s_CurveHash, EditorGUIUtility.native, position);
-            //            EditorGUI.DoGradientField(EditorGUI.PrefixLabel(position, controlID2, label), controlID2, null, property);
-            //            break;
-            //        }
         }
 
-        private bool Begin(SPUD spud, Rect position, SerializedProperty property, GUIContent label)
+        private bool Begin(SharedData data, Rect position, SerializedProperty property, GUIContent label)
         {
             label = EditorGUI.BeginProperty(position, label, property);
             label.text = " " + label.text;
             position.height = 16;
             EditorGUIUtility.labelWidth = 180;
             EditorGUI.BeginChangeCheck();
-            spud.expanded = EditorGUI.ToggleLeft(position, label, spud.expanded == true);
+            data.expanded = EditorGUI.ToggleLeft(position, label, data.expanded == true);
             return EditorGUI.EndChangeCheck();
         }
 
@@ -158,22 +94,12 @@ namespace TouchScript.Editor.Utils.PropertyDrawers
             EditorGUI.EndProperty();
         }
 
-        private SPUD updateExpanded(SerializedProperty property)
+        private SharedData updateExpanded(SerializedProperty property)
         {
-            var storage = SerializedPropertyUserData<SPUD>.Instance;
-            try
-            {
-                var spud = storage[property];
-                if (spud == null)
-                    storage[property] = spud = new SPUD() { expanded = !isNull(property) };
-                return spud;
-            }
-            catch (System.ArgumentException)
-            {
-                if (expanded == null)
-                    expanded = new SPUD() { expanded = !isNull(property) };
-                return expanded;
-            }
+            var storage = SerializedPropertyUserData<SharedData>.Instance;
+            var data = storage[property];
+            if (data == null) storage[property] = data = new SharedData() { expanded = !isNull(property) };
+            return data;
         }
 
         private bool isNull(SerializedProperty property)

--- a/Source/Assets/TouchScript/Editor/Utils/SerializedPropertyUserData.cs
+++ b/Source/Assets/TouchScript/Editor/Utils/SerializedPropertyUserData.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace TouchScript.Editor.Utils
+{
+    internal sealed class SerializedPropertyUserData<TUserData> where TUserData : class
+    {
+        const int GCThreshold = 1000;
+
+        static SerializedPropertyUserData<TUserData> s_instance = new SerializedPropertyUserData<TUserData>();
+
+        public static SerializedPropertyUserData<TUserData> Instance { get { return s_instance; } }
+
+        private struct Storage
+        {
+            internal Object targetObject;
+            internal TUserData userData;
+        }
+
+        private Dictionary<string, Storage> storage = new Dictionary<string, Storage>();
+        private int accessCount = 0;
+
+        internal TUserData this[SerializedProperty property]
+        {
+            get
+            {
+                GC();
+                var key = MakeKey(property);
+                Storage s;
+                if (!storage.TryGetValue(key, out s))
+                    return null;
+                return s.userData;
+            }
+            set
+            {
+                var key = MakeKey(property);
+                storage[key] = new Storage
+                {
+                    targetObject = property.serializedObject.targetObject,
+                    userData = value,
+                };
+            }
+        }
+
+        private string MakeKey(SerializedProperty property)
+        {
+            if (property == null)
+                throw new System.ArgumentException();
+            var so = property.serializedObject;
+            if (so == null)
+                throw new System.ArgumentException();
+            var to = so.targetObject;
+            if (to == null)
+                throw new System.ArgumentException();
+            return to.GetInstanceID().ToString() + "," + property.propertyPath;
+        }
+
+        private void GC()
+        {
+            ++ accessCount;
+            if (accessCount < GCThreshold)
+                return;
+            accessCount = 0;
+            var newStorage = new Dictionary<string, Storage>();
+            foreach (var kv in storage)
+            {
+                if (kv.Value.targetObject != null)
+                    newStorage[kv.Key] = kv.Value;
+                //else Debug.LogFormat("GC: Expired: {0}", kv.Key);
+            }
+            storage = newStorage;
+        }
+    }
+}

--- a/Source/Assets/TouchScript/Editor/Utils/SerializedPropertyUserData.cs
+++ b/Source/Assets/TouchScript/Editor/Utils/SerializedPropertyUserData.cs
@@ -1,45 +1,30 @@
 using System.Collections.Generic;
+using System.Text;
 using UnityEditor;
-using UnityEngine;
 
 namespace TouchScript.Editor.Utils
 {
     internal sealed class SerializedPropertyUserData<TUserData> where TUserData : class
     {
-        const int GCThreshold = 1000;
+        public static SerializedPropertyUserData<TUserData> Instance { get { return instance; } }
 
-        static SerializedPropertyUserData<TUserData> s_instance = new SerializedPropertyUserData<TUserData>();
-
-        public static SerializedPropertyUserData<TUserData> Instance { get { return s_instance; } }
-
-        private struct Storage
-        {
-            internal Object targetObject;
-            internal TUserData userData;
-        }
-
-        private Dictionary<string, Storage> storage = new Dictionary<string, Storage>();
-        private int accessCount = 0;
+        private static SerializedPropertyUserData<TUserData> instance = new SerializedPropertyUserData<TUserData>();
+        private static StringBuilder sb = new StringBuilder();
+        private Dictionary<string, TUserData> storage = new Dictionary<string, TUserData>();
 
         internal TUserData this[SerializedProperty property]
         {
             get
             {
-                GC();
                 var key = MakeKey(property);
-                Storage s;
-                if (!storage.TryGetValue(key, out s))
-                    return null;
-                return s.userData;
+                TUserData data;
+                if (!storage.TryGetValue(key, out data)) return null;
+                return data;
             }
             set
             {
                 var key = MakeKey(property);
-                storage[key] = new Storage
-                {
-                    targetObject = property.serializedObject.targetObject,
-                    userData = value,
-                };
+                storage[key] = value;
             }
         }
 
@@ -53,23 +38,10 @@ namespace TouchScript.Editor.Utils
             var to = so.targetObject;
             if (to == null)
                 throw new System.ArgumentException();
-            return to.GetInstanceID().ToString() + "," + property.propertyPath;
-        }
-
-        private void GC()
-        {
-            ++ accessCount;
-            if (accessCount < GCThreshold)
-                return;
-            accessCount = 0;
-            var newStorage = new Dictionary<string, Storage>();
-            foreach (var kv in storage)
-            {
-                if (kv.Value.targetObject != null)
-                    newStorage[kv.Key] = kv.Value;
-                //else Debug.LogFormat("GC: Expired: {0}", kv.Key);
-            }
-            storage = newStorage;
+            sb.Length = 0;
+            sb.Append(to.GetInstanceID().ToString());
+            sb.Append(property.propertyPath);
+            return sb.ToString();
         }
     }
 }

--- a/Source/Assets/TouchScript/Editor/Utils/SerializedPropertyUserData.cs.meta
+++ b/Source/Assets/TouchScript/Editor/Utils/SerializedPropertyUserData.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 435634b8b79056f4f860513441a571b2
+timeCreated: 1512537208
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Source/Assets/TouchScript/Examples/Camera/Camera.unity
+++ b/Source/Assets/TouchScript/Examples/Camera/Camera.unity
@@ -769,7 +769,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 74ae431eff8434b0897d3f7f1cff4311, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  debugMode: 0
   OnStateChange:
     m_PersistentCalls:
       m_Calls: []
@@ -862,7 +861,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 74ae431eff8434b0897d3f7f1cff4311, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  debugMode: 0
   OnStateChange:
     m_PersistentCalls:
       m_Calls: []

--- a/Source/Assets/TouchScript/Examples/Camera/Camera.unity
+++ b/Source/Assets/TouchScript/Examples/Camera/Camera.unity
@@ -484,34 +484,6 @@ Prefab:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
@@ -847,7 +819,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bc7fd33c57d694994b0ab9f33fcdcbea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Name: Fullscreen @ Camera
+  layerName: 
   type: 0
   _camera: {fileID: 62216957}
 --- !u!114 &930800606

--- a/Source/Assets/TouchScript/Examples/Checkers/Checkers.unity
+++ b/Source/Assets/TouchScript/Examples/Checkers/Checkers.unity
@@ -206,7 +206,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7e5768c36d1bb4acea50bd233372843a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Name: Camera
+  layerName: 
   basicEditor: 1
   advancedProps: 0
   hitProps: 0
@@ -485,38 +485,14 @@ Prefab:
       propertyPath: layers.Array.size
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 11400000, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
       propertyPath: layers.Array.data[0]
       value: 
       objectReference: {fileID: 62216953}
+    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
   m_IsPrefabParent: 0

--- a/Source/Assets/TouchScript/Examples/Colors/Colors.unity
+++ b/Source/Assets/TouchScript/Examples/Colors/Colors.unity
@@ -152,7 +152,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7e5768c36d1bb4acea50bd233372843a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Name: Camera
+  layerName: 
   basicEditor: 1
   advancedProps: 0
   hitProps: 0
@@ -316,34 +316,6 @@ Prefab:
     m_Modifications:
     - target: {fileID: 11400000, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
       propertyPath: layers.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}

--- a/Source/Assets/TouchScript/Examples/Cube/Cube.unity
+++ b/Source/Assets/TouchScript/Examples/Cube/Cube.unity
@@ -152,7 +152,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7e5768c36d1bb4acea50bd233372843a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Name: Camera
+  layerName: 
   basicEditor: 1
   advancedProps: 0
   hitProps: 0
@@ -343,34 +343,6 @@ Prefab:
     - target: {fileID: 11400000, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
       propertyPath: layers.Array.size
       value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 11400000, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
       propertyPath: layers.Array.data[0]
@@ -1028,7 +1000,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7e5768c36d1bb4acea50bd233372843a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Name: RenderTexture Camera
+  layerName: 
   basicEditor: 1
   advancedProps: 0
   hitProps: 0

--- a/Source/Assets/TouchScript/Examples/Cube/Cube.unity
+++ b/Source/Assets/TouchScript/Examples/Cube/Cube.unity
@@ -1,19 +1,19 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
 --- !u!29 &1
-SceneSettings:
+OcclusionCullingSettings:
   m_ObjectHideFlags: 0
-  m_PVSData: 
-  m_PVSObjectsArray: []
-  m_PVSPortalsArray: []
+  serializedVersion: 2
   m_OcclusionBakeSettings:
     smallestOccluder: 5
     smallestHole: 0.25
     backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 6
+  serializedVersion: 8
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -25,6 +25,7 @@ RenderSettings:
   m_AmbientGroundColor: {r: 0.2, g: 0.2, b: 0.2, a: 1}
   m_AmbientIntensity: 1
   m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
   m_SkyboxMaterial: {fileID: 2100000, guid: a07fadb24ea940240afba3afc1a692cc, type: 2}
   m_HaloStrength: 0.5
   m_FlareStrength: 1
@@ -37,12 +38,12 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
 --- !u!157 &4
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 6
+  serializedVersion: 9
   m_GIWorkflowMode: 1
-  m_LightmapsMode: 1
   m_GISettings:
     serializedVersion: 2
     m_BounceScale: 1
@@ -53,51 +54,73 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    serializedVersion: 3
+    serializedVersion: 8
     m_Resolution: 1
     m_BakeResolution: 50
     m_TextureWidth: 1024
     m_TextureHeight: 1024
+    m_AO: 0
     m_AOMaxDistance: 1
-    m_Padding: 2
     m_CompAOExponent: 0
+    m_CompAOExponentDirect: 0
+    m_Padding: 2
     m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
     m_TextureCompression: 0
     m_FinalGather: 0
+    m_FinalGatherFiltering: 1
     m_FinalGatherRayCount: 1024
     m_ReflectionCompression: 2
+    m_MixedBakeMode: 1
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVRFiltering: 0
+    m_PVRFilteringMode: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousColorSigma: 1
+    m_PVRFilteringAtrousNormalSigma: 1
+    m_PVRFilteringAtrousPositionSigma: 1
   m_LightingDataAsset: {fileID: 0}
-  m_RuntimeCPUUsage: 25
+  m_ShadowMaskMode: 2
 --- !u!196 &5
 NavMeshSettings:
   serializedVersion: 2
   m_ObjectHideFlags: 0
   m_BuildSettings:
     serializedVersion: 2
+    agentTypeID: 0
     agentRadius: 0.5
     agentHeight: 2
     agentSlope: 45
     agentClimb: 0.4
     ledgeDropHeight: 0
     maxJumpAcrossDistance: 0
-    accuratePlacement: 0
     minRegionArea: 2
-    cellSize: 0.16666666
     manualCellSize: 0
+    cellSize: 0.16666666
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
   m_NavMeshData: {fileID: 0}
 --- !u!1 &62216951
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 62216952}
-  - 20: {fileID: 62216957}
-  - 92: {fileID: 62216956}
-  - 124: {fileID: 62216955}
-  - 81: {fileID: 62216954}
-  - 114: {fileID: 62216953}
+  - component: {fileID: 62216952}
+  - component: {fileID: 62216957}
+  - component: {fileID: 62216956}
+  - component: {fileID: 62216955}
+  - component: {fileID: 62216954}
+  - component: {fileID: 62216953}
   m_Layer: 0
   m_Name: Camera
   m_TagString: MainCamera
@@ -114,10 +137,10 @@ Transform:
   m_LocalRotation: {x: 0.97875386, y: 0, z: 0, w: 0.20503876}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 23.6635, y: -180, z: -180}
   m_Children: []
   m_Father: {fileID: 930800601}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 23.6635, y: -180, z: -180}
 --- !u!114 &62216953
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -130,6 +153,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Name: Camera
+  basicEditor: 1
   advancedProps: 0
   hitProps: 0
   hit3DObjects: 1
@@ -191,6 +215,8 @@ Camera:
   m_TargetDisplay: 0
   m_TargetEye: 3
   m_HDR: 0
+  m_AllowMSAA: 1
+  m_ForceIntoRT: 0
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
@@ -200,10 +226,10 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 172819028}
-  - 114: {fileID: 172819029}
+  - component: {fileID: 172819028}
+  - component: {fileID: 172819029}
   m_Layer: 5
   m_Name: Scale
   m_TagString: Untagged
@@ -220,12 +246,12 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 732284830}
   - {fileID: 891499233}
   m_Father: {fileID: 250857271}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
@@ -254,10 +280,10 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 250857271}
-  - 114: {fileID: 250857270}
+  - component: {fileID: 250857271}
+  - component: {fileID: 250857270}
   m_Layer: 5
   m_Name: List
   m_TagString: Untagged
@@ -285,6 +311,8 @@ MonoBehaviour:
   m_Spacing: 0
   m_ChildForceExpandWidth: 1
   m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
 --- !u!224 &250857271
 RectTransform:
   m_ObjectHideFlags: 0
@@ -294,12 +322,12 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1679844150}
   - {fileID: 172819028}
   m_Father: {fileID: 1981142013}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
@@ -360,11 +388,11 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 732284830}
-  - 222: {fileID: 732284829}
-  - 114: {fileID: 732284828}
+  - component: {fileID: 732284830}
+  - component: {fileID: 732284829}
+  - component: {fileID: 732284828}
   m_Layer: 5
   m_Name: Image
   m_TagString: Untagged
@@ -414,10 +442,10 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 172819028}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 31, y: 0}
@@ -428,11 +456,11 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 740851132}
-  - 223: {fileID: 740851135}
-  - 114: {fileID: 740851134}
+  - component: {fileID: 740851132}
+  - component: {fileID: 740851135}
+  - component: {fileID: 740851134}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -449,12 +477,12 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1981142013}
   - {fileID: 1552723601}
   m_Father: {fileID: 0}
   m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
@@ -488,7 +516,7 @@ Canvas:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 740851131}
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_RenderMode: 0
   m_Camera: {fileID: 0}
   m_PlaneDistance: 100
@@ -497,6 +525,7 @@ Canvas:
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 25
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
@@ -505,12 +534,12 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 891499233}
-  - 222: {fileID: 891499236}
-  - 114: {fileID: 891499235}
-  - 114: {fileID: 891499234}
+  - component: {fileID: 891499233}
+  - component: {fileID: 891499236}
+  - component: {fileID: 891499235}
+  - component: {fileID: 891499234}
   m_Layer: 5
   m_Name: Text
   m_TagString: Untagged
@@ -527,10 +556,10 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 172819028}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 177.5, y: 0}
@@ -596,11 +625,11 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 930800601}
-  - 114: {fileID: 930800602}
-  - 114: {fileID: 930800603}
+  - component: {fileID: 930800601}
+  - component: {fileID: 930800602}
+  - component: {fileID: 930800603}
   m_Layer: 0
   m_Name: Scene
   m_TagString: Untagged
@@ -617,7 +646,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 2135305920}
   - {fileID: 62216952}
@@ -625,6 +653,7 @@ Transform:
   - {fileID: 1459600543}
   m_Father: {fileID: 0}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &930800602
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -654,14 +683,14 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 963048124}
-  - 33: {fileID: 963048127}
-  - 65: {fileID: 963048126}
-  - 23: {fileID: 963048125}
-  - 114: {fileID: 963048129}
-  - 114: {fileID: 963048128}
+  - component: {fileID: 963048124}
+  - component: {fileID: 963048127}
+  - component: {fileID: 963048126}
+  - component: {fileID: 963048125}
+  - component: {fileID: 963048129}
+  - component: {fileID: 963048128}
   m_Layer: 0
   m_Name: Image
   m_TagString: Untagged
@@ -678,10 +707,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 1, w: -0.00000016292068}
   m_LocalPosition: {x: 0, y: 0, z: 5.16}
   m_LocalScale: {x: 2, y: 2, z: 0.047008425}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1459600543}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &963048125
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -691,22 +720,28 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 08401881b8b2542f1b283eac02c865aa, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 1
-  m_ReflectionProbeUsage: 1
   m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!65 &963048126
 BoxCollider:
@@ -760,13 +795,12 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
+  basicEditor: 1
   generalProps: 0
   limitsProps: 0
   advancedProps: 0
   minPointers: 0
   maxPointers: 0
-  combinePointers: 0
-  combinePointersInterval: 0.3
   useSendMessage: 0
   sendStateChangeMessages: 0
   sendMessageTarget: {fileID: 0}
@@ -800,11 +834,11 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 1138005900}
-  - 222: {fileID: 1138005902}
-  - 114: {fileID: 1138005901}
+  - component: {fileID: 1138005900}
+  - component: {fileID: 1138005902}
+  - component: {fileID: 1138005901}
   m_Layer: 5
   m_Name: Image
   m_TagString: Untagged
@@ -821,10 +855,10 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1679844150}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 31, y: 0}
@@ -868,12 +902,12 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 1408280581}
-  - 222: {fileID: 1408280583}
-  - 114: {fileID: 1408280582}
-  - 114: {fileID: 1408280584}
+  - component: {fileID: 1408280581}
+  - component: {fileID: 1408280583}
+  - component: {fileID: 1408280582}
+  - component: {fileID: 1408280584}
   m_Layer: 5
   m_Name: Text
   m_TagString: Untagged
@@ -890,10 +924,10 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1679844150}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 177.5, y: 0}
@@ -957,11 +991,11 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 1459600543}
-  - 20: {fileID: 1459600547}
-  - 114: {fileID: 1459600544}
+  - component: {fileID: 1459600543}
+  - component: {fileID: 1459600547}
+  - component: {fileID: 1459600544}
   m_Layer: 0
   m_Name: Scene Camera
   m_TagString: Untagged
@@ -978,11 +1012,11 @@ Transform:
   m_LocalRotation: {x: 0, y: 0.74471927, z: 0, w: -0.66737795}
   m_LocalPosition: {x: 1000, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 963048124}
   m_Father: {fileID: 930800601}
   m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1459600544
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -995,6 +1029,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Name: RenderTexture Camera
+  basicEditor: 1
   advancedProps: 0
   hitProps: 0
   hit3DObjects: 1
@@ -1035,6 +1070,8 @@ Camera:
   m_TargetDisplay: 0
   m_TargetEye: 3
   m_HDR: 0
+  m_AllowMSAA: 1
+  m_ForceIntoRT: 0
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
@@ -1044,12 +1081,12 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 1552723601}
-  - 222: {fileID: 1552723603}
-  - 114: {fileID: 1552723602}
-  - 114: {fileID: 1552723604}
+  - component: {fileID: 1552723601}
+  - component: {fileID: 1552723603}
+  - component: {fileID: 1552723602}
+  - component: {fileID: 1552723604}
   m_Layer: 5
   m_Name: Description
   m_TagString: Untagged
@@ -1066,10 +1103,10 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 740851132}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 178, y: 48.2}
@@ -1138,10 +1175,10 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 1679844150}
-  - 114: {fileID: 1679844151}
+  - component: {fileID: 1679844150}
+  - component: {fileID: 1679844151}
   m_Layer: 5
   m_Name: Drag
   m_TagString: Untagged
@@ -1158,12 +1195,12 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1138005900}
   - {fileID: 1408280581}
   m_Father: {fileID: 250857271}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
@@ -1192,10 +1229,10 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 1764701050}
-  - 114: {fileID: 1764701049}
+  - component: {fileID: 1764701050}
+  - component: {fileID: 1764701049}
   m_Layer: 0
   m_Name: EventSystem
   m_TagString: Untagged
@@ -1226,10 +1263,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1772227325
 Prefab:
   m_ObjectHideFlags: 0
@@ -1271,14 +1308,14 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 1880100173}
-  - 33: {fileID: 1880100172}
-  - 23: {fileID: 1880100170}
-  - 114: {fileID: 1880100169}
-  - 114: {fileID: 1880100168}
-  - 64: {fileID: 1880100171}
+  - component: {fileID: 1880100173}
+  - component: {fileID: 1880100172}
+  - component: {fileID: 1880100170}
+  - component: {fileID: 1880100169}
+  - component: {fileID: 1880100168}
+  - component: {fileID: 1880100171}
   m_Layer: 0
   m_Name: Cube
   m_TagString: Untagged
@@ -1297,7 +1334,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71f21ea441ad54e2395b6cb5da4f4e9f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  advancedProps: 0
+  basicEditor: 1
   Width: 512
   Height: 512
 --- !u!114 &1880100169
@@ -1316,13 +1353,12 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
+  basicEditor: 1
   generalProps: 0
   limitsProps: 0
   advancedProps: 0
   minPointers: 0
   maxPointers: 0
-  combinePointers: 0
-  combinePointersInterval: 0.3
   useSendMessage: 0
   sendStateChangeMessages: 0
   sendMessageTarget: {fileID: 0}
@@ -1339,22 +1375,28 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 7414b9f60fb074ad4a74546362f312ab, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 1
-  m_ReflectionProbeUsage: 1
   m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!64 &1880100171
 MeshCollider:
@@ -1367,6 +1409,8 @@ MeshCollider:
   m_Enabled: 1
   serializedVersion: 2
   m_Convex: 0
+  m_InflateMesh: 0
+  m_SkinWidth: 0.01
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!33 &1880100172
 MeshFilter:
@@ -1384,18 +1428,18 @@ Transform:
   m_LocalRotation: {x: 0, y: -0.32758188, z: 0, w: 0.9448228}
   m_LocalPosition: {x: 0.05, y: -2.9, z: -6.5}
   m_LocalScale: {x: -2.610165, y: -2.610164, z: 2.6101644}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 930800601}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1981142012
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 1981142013}
+  - component: {fileID: 1981142013}
   m_Layer: 5
   m_Name: Panel
   m_TagString: Untagged
@@ -1412,11 +1456,11 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 250857271}
   m_Father: {fileID: 740851132}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0.25263783, y: 1}
   m_AnchoredPosition: {x: 5, y: 50}
@@ -1427,10 +1471,10 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 2135305920}
-  - 108: {fileID: 2135305921}
+  - component: {fileID: 2135305920}
+  - component: {fileID: 2135305921}
   m_Layer: 0
   m_Name: Directional light
   m_TagString: Untagged
@@ -1447,10 +1491,10 @@ Transform:
   m_LocalRotation: {x: 0.32484895, y: -0.86744815, z: 0.043405317, w: 0.37432998}
   m_LocalPosition: {x: 6.1004148, y: 15.540384, z: -20.566225}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 930800601}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!108 &2135305921
 Light:
   m_ObjectHideFlags: 0
@@ -1458,7 +1502,7 @@ Light:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2135305919}
   m_Enabled: 1
-  serializedVersion: 6
+  serializedVersion: 8
   m_Type: 1
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_Intensity: 1.3
@@ -1468,6 +1512,7 @@ Light:
   m_Shadows:
     m_Type: 2
     m_Resolution: 3
+    m_CustomResolution: -1
     m_Strength: 0.56
     m_Bias: 0.1
     m_NormalBias: 0.4
@@ -1480,7 +1525,9 @@ Light:
     serializedVersion: 2
     m_Bits: 4294967295
   m_Lightmapping: 1
+  m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
-  m_AreaSize: {x: 1, y: 1}

--- a/Source/Assets/TouchScript/Examples/Cube/Scripts/RedirectInput.cs
+++ b/Source/Assets/TouchScript/Examples/Cube/Scripts/RedirectInput.cs
@@ -42,9 +42,8 @@ namespace TouchScript.Examples.Cube
             return true;
         }
 
-        protected override void OnEnable()
+        protected override void init()
         {
-            base.OnEnable();
             gesture = GetComponent<MetaGesture>();
             if (gesture)
             {

--- a/Source/Assets/TouchScript/Examples/Multiuser/Multiuser.unity
+++ b/Source/Assets/TouchScript/Examples/Multiuser/Multiuser.unity
@@ -1131,34 +1131,6 @@ Prefab:
       value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
@@ -1182,6 +1154,10 @@ Prefab:
       propertyPath: layers.Array.data[4]
       value: 
       objectReference: {fileID: 2041906757}
+    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
   m_IsPrefabParent: 0
@@ -1429,7 +1405,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bc7fd33c57d694994b0ab9f33fcdcbea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Name: Fullscreen @ Right 3D Camera
+  layerName: 
   type: 1
   _camera: {fileID: 871116139}
 --- !u!4 &723351974
@@ -1773,7 +1749,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7e5768c36d1bb4acea50bd233372843a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Name: Right 3D Camera
+  layerName: 
   basicEditor: 1
   advancedProps: 0
   hitProps: 0
@@ -3038,8 +3014,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7e5768c36d1bb4acea50bd233372843a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Name: 2D Camera
-  basicEditor: 1
+  layerName: 
+  basicEditor: 0
   advancedProps: 0
   hitProps: 0
   hit3DObjects: 0
@@ -3767,7 +3743,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7e5768c36d1bb4acea50bd233372843a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Name: Left 3D Camera
+  layerName: 
   basicEditor: 1
   advancedProps: 0
   hitProps: 0
@@ -3826,7 +3802,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bc7fd33c57d694994b0ab9f33fcdcbea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Name: Fullscreen @ Left 3D Camera
+  layerName: 
   type: 1
   _camera: {fileID: 1969944224}
 --- !u!114 &2041906758

--- a/Source/Assets/TouchScript/Examples/Multiuser/Multiuser.unity
+++ b/Source/Assets/TouchScript/Examples/Multiuser/Multiuser.unity
@@ -1,19 +1,19 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
 --- !u!29 &1
-SceneSettings:
+OcclusionCullingSettings:
   m_ObjectHideFlags: 0
-  m_PVSData: 
-  m_PVSObjectsArray: []
-  m_PVSPortalsArray: []
+  serializedVersion: 2
   m_OcclusionBakeSettings:
     smallestOccluder: 5
     smallestHole: 0.25
     backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 6
+  serializedVersion: 8
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -25,6 +25,7 @@ RenderSettings:
   m_AmbientGroundColor: {r: 0.2, g: 0.2, b: 0.2, a: 1}
   m_AmbientIntensity: 1
   m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
   m_SkyboxMaterial: {fileID: 2100000, guid: a07fadb24ea940240afba3afc1a692cc, type: 2}
   m_HaloStrength: 0.5
   m_FlareStrength: 1
@@ -37,12 +38,12 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
 --- !u!157 &4
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 6
+  serializedVersion: 9
   m_GIWorkflowMode: 1
-  m_LightmapsMode: 1
   m_GISettings:
     serializedVersion: 2
     m_BounceScale: 1
@@ -53,37 +54,59 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    serializedVersion: 3
+    serializedVersion: 8
     m_Resolution: 1
     m_BakeResolution: 50
     m_TextureWidth: 1024
     m_TextureHeight: 1024
+    m_AO: 0
     m_AOMaxDistance: 1
-    m_Padding: 2
     m_CompAOExponent: 0
+    m_CompAOExponentDirect: 0
+    m_Padding: 2
     m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
     m_TextureCompression: 0
     m_FinalGather: 0
+    m_FinalGatherFiltering: 1
     m_FinalGatherRayCount: 1024
     m_ReflectionCompression: 2
+    m_MixedBakeMode: 1
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVRFiltering: 0
+    m_PVRFilteringMode: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousColorSigma: 1
+    m_PVRFilteringAtrousNormalSigma: 1
+    m_PVRFilteringAtrousPositionSigma: 1
   m_LightingDataAsset: {fileID: 0}
-  m_RuntimeCPUUsage: 25
+  m_ShadowMaskMode: 2
 --- !u!196 &5
 NavMeshSettings:
   serializedVersion: 2
   m_ObjectHideFlags: 0
   m_BuildSettings:
     serializedVersion: 2
+    agentTypeID: 0
     agentRadius: 0.5
     agentHeight: 2
     agentSlope: 45
     agentClimb: 0.4
     ledgeDropHeight: 0
     maxJumpAcrossDistance: 0
-    accuratePlacement: 0
     minRegionArea: 2
-    cellSize: 0.16666666
     manualCellSize: 0
+    cellSize: 0.16666666
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
   m_NavMeshData: {fileID: 0}
 --- !u!4 &67866218 stripped
 Transform:
@@ -416,13 +439,13 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 119512, guid: 4af91eff6c67b4995be4765a62f7eb5d, type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 269580356}
-  - 33: {fileID: 269580360}
-  - 23: {fileID: 269580359}
-  - 65: {fileID: 269580358}
-  - 54: {fileID: 269580357}
+  - component: {fileID: 269580356}
+  - component: {fileID: 269580360}
+  - component: {fileID: 269580359}
+  - component: {fileID: 269580358}
+  - component: {fileID: 269580357}
   m_Layer: 0
   m_Name: Body
   m_TagString: Untagged
@@ -439,10 +462,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: -0.101, z: 0}
   m_LocalScale: {x: 10, y: 0.2, z: 10}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1164346782}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!54 &269580357
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -481,22 +504,28 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: bade3b3ccc3024624b44815e95a6af4e, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 0
-  m_ReflectionProbeUsage: 1
   m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &269580360
 MeshFilter:
@@ -515,12 +544,12 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 437243916}
-  - 222: {fileID: 437243919}
-  - 114: {fileID: 437243918}
-  - 114: {fileID: 437243917}
+  - component: {fileID: 437243916}
+  - component: {fileID: 437243919}
+  - component: {fileID: 437243918}
+  - component: {fileID: 437243917}
   m_Layer: 5
   m_Name: Text
   m_TagString: Untagged
@@ -537,10 +566,10 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1622510500}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 177.5, y: 0}
@@ -608,11 +637,11 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 479835906}
-  - 223: {fileID: 479835909}
-  - 114: {fileID: 479835908}
+  - component: {fileID: 479835906}
+  - component: {fileID: 479835909}
+  - component: {fileID: 479835908}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -629,12 +658,12 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1360329865}
   - {fileID: 878382147}
   m_Father: {fileID: 0}
   m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
@@ -668,7 +697,7 @@ Canvas:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 479835905}
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_RenderMode: 0
   m_Camera: {fileID: 0}
   m_PlaneDistance: 100
@@ -677,6 +706,7 @@ Canvas:
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 25
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
@@ -689,13 +719,13 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 100000, guid: e489ac3472ad77e4496ad84b9af2013a, type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 501236165}
-  - 212: {fileID: 501236169}
-  - 61: {fileID: 501236168}
-  - 114: {fileID: 501236167}
-  - 114: {fileID: 501236166}
+  - component: {fileID: 501236165}
+  - component: {fileID: 501236169}
+  - component: {fileID: 501236168}
+  - component: {fileID: 501236167}
+  - component: {fileID: 501236166}
   m_Layer: 0
   m_Name: Unity_Logo
   m_TagString: Untagged
@@ -712,10 +742,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -1.2, y: -22.1, z: 0}
   m_LocalScale: {x: 3, y: 3, z: 3}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 2096873804}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &501236166
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -733,13 +763,12 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
+  basicEditor: 1
   generalProps: 0
   limitsProps: 0
   advancedProps: 0
   minPointers: 0
   maxPointers: 0
-  combinePointers: 0
-  combinePointersInterval: 0.3
   useSendMessage: 0
   sendStateChangeMessages: 0
   sendMessageTarget: {fileID: 0}
@@ -755,6 +784,8 @@ MonoBehaviour:
   numberOfTapsRequired: 1
   timeLimit: Infinity
   distanceLimit: Infinity
+  combinePointers: 0
+  combinePointersInterval: 0.3
 --- !u!114 &501236167
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -779,9 +810,20 @@ BoxCollider2D:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_UsedByEffector: 0
+  m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2.56, y: 2.56}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
   serializedVersion: 2
   m_Size: {x: 2, y: 2}
+  m_EdgeRadius: 0
 --- !u!212 &501236169
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -792,39 +834,50 @@ SpriteRenderer:
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000e000000000000000, type: 0}
-  m_SubsetIndices: 
-  m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_SelectedEditorRenderState: 0
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 533b9df4691d947d9921a0053b5ce231, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
 --- !u!1 &519196852
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 119512, guid: 4af91eff6c67b4995be4765a62f7eb5d, type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 519196853}
-  - 33: {fileID: 519196857}
-  - 23: {fileID: 519196856}
-  - 65: {fileID: 519196855}
-  - 54: {fileID: 519196854}
+  - component: {fileID: 519196853}
+  - component: {fileID: 519196857}
+  - component: {fileID: 519196856}
+  - component: {fileID: 519196855}
+  - component: {fileID: 519196854}
   m_Layer: 0
   m_Name: Body
   m_TagString: Untagged
@@ -841,10 +894,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: -0.101, z: 0}
   m_LocalScale: {x: 10, y: 0.2, z: 10}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1388179442}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!54 &519196854
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -883,22 +936,28 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: bade3b3ccc3024624b44815e95a6af4e, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 0
-  m_ReflectionProbeUsage: 1
   m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &519196857
 MeshFilter:
@@ -913,13 +972,13 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 100000, guid: e489ac3472ad77e4496ad84b9af2013a, type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 529543779}
-  - 212: {fileID: 529543783}
-  - 61: {fileID: 529543782}
-  - 114: {fileID: 529543781}
-  - 114: {fileID: 529543780}
+  - component: {fileID: 529543779}
+  - component: {fileID: 529543783}
+  - component: {fileID: 529543782}
+  - component: {fileID: 529543781}
+  - component: {fileID: 529543780}
   m_Layer: 0
   m_Name: Unity_Logo
   m_TagString: Untagged
@@ -936,10 +995,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 6.6, y: -22.1, z: 0}
   m_LocalScale: {x: 3, y: 3, z: 3}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 2096873804}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &529543780
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -957,13 +1016,12 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
+  basicEditor: 1
   generalProps: 0
   limitsProps: 0
   advancedProps: 0
   minPointers: 0
   maxPointers: 0
-  combinePointers: 0
-  combinePointersInterval: 0.3
   useSendMessage: 0
   sendStateChangeMessages: 0
   sendMessageTarget: {fileID: 0}
@@ -979,6 +1037,8 @@ MonoBehaviour:
   numberOfTapsRequired: 1
   timeLimit: Infinity
   distanceLimit: Infinity
+  combinePointers: 0
+  combinePointersInterval: 0.3
 --- !u!114 &529543781
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1003,9 +1063,20 @@ BoxCollider2D:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_UsedByEffector: 0
+  m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2.56, y: 2.56}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
   serializedVersion: 2
   m_Size: {x: 2, y: 2}
+  m_EdgeRadius: 0
 --- !u!212 &529543783
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -1016,27 +1087,38 @@ SpriteRenderer:
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000e000000000000000, type: 0}
-  m_SubsetIndices: 
-  m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_SelectedEditorRenderState: 0
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 533b9df4691d947d9921a0053b5ce231, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
 --- !u!1001 &543251036
 Prefab:
   m_ObjectHideFlags: 0
@@ -1242,9 +1324,9 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 655915741}
+  - component: {fileID: 655915741}
   m_Layer: 0
   m_Name: Scene
   m_TagString: Untagged
@@ -1261,7 +1343,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1969944223}
   - {fileID: 871116140}
@@ -1272,6 +1353,7 @@ Transform:
   - {fileID: 1810922940}
   m_Father: {fileID: 0}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &695109447
 Prefab:
   m_ObjectHideFlags: 0
@@ -1323,12 +1405,12 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 723351974}
-  - 114: {fileID: 723351973}
-  - 114: {fileID: 723351976}
-  - 114: {fileID: 723351975}
+  - component: {fileID: 723351974}
+  - component: {fileID: 723351973}
+  - component: {fileID: 723351976}
+  - component: {fileID: 723351975}
   m_Layer: 0
   m_Name: Right
   m_TagString: Untagged
@@ -1359,11 +1441,11 @@ Transform:
   m_LocalRotation: {x: 0, y: 0.3476719, z: 0, w: -0.9376163}
   m_LocalPosition: {x: 100, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1388179442}
   m_Father: {fileID: 655915741}
   m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &723351975
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1397,13 +1479,12 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
+  basicEditor: 1
   generalProps: 0
   limitsProps: 0
   advancedProps: 0
   minPointers: 0
   maxPointers: 0
-  combinePointers: 0
-  combinePointersInterval: 0.3
   useSendMessage: 0
   sendStateChangeMessages: 0
   sendMessageTarget: {fileID: 0}
@@ -1441,9 +1522,9 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 750573663}
+  - component: {fileID: 750573663}
   m_Layer: 0
   m_Name: Container
   m_TagString: Untagged
@@ -1460,7 +1541,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1828860094}
   - {fileID: 2014918824}
@@ -1480,15 +1560,16 @@ Transform:
   - {fileID: 1522091850}
   m_Father: {fileID: 1164346782}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &759689236
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 759689238}
-  - 114: {fileID: 759689237}
+  - component: {fileID: 759689238}
+  - component: {fileID: 759689237}
   m_Layer: 0
   m_Name: EventSystem
   m_TagString: Untagged
@@ -1519,10 +1600,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &804482168
 Prefab:
   m_ObjectHideFlags: 0
@@ -1620,11 +1701,11 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 871116140}
-  - 20: {fileID: 871116139}
-  - 114: {fileID: 871116141}
+  - component: {fileID: 871116140}
+  - component: {fileID: 871116139}
+  - component: {fileID: 871116141}
   m_Layer: 0
   m_Name: Right 3D Camera
   m_TagString: Untagged
@@ -1662,6 +1743,8 @@ Camera:
   m_TargetDisplay: 0
   m_TargetEye: 3
   m_HDR: 0
+  m_AllowMSAA: 1
+  m_ForceIntoRT: 0
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
@@ -1675,10 +1758,10 @@ Transform:
   m_LocalRotation: {x: -0.42646128, y: 0.4520982, z: -0.2610191, w: -0.7386522}
   m_LocalPosition: {x: 104.46, y: 9.66, z: -2.17}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 60, y: -62.9381, z: 0}
   m_Children: []
   m_Father: {fileID: 655915741}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 60, y: -62.9381, z: 0}
 --- !u!114 &871116141
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1691,6 +1774,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Name: Right 3D Camera
+  basicEditor: 1
   advancedProps: 0
   hitProps: 0
   hit3DObjects: 1
@@ -1710,12 +1794,12 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 878382147}
-  - 222: {fileID: 878382150}
-  - 114: {fileID: 878382149}
-  - 114: {fileID: 878382148}
+  - component: {fileID: 878382147}
+  - component: {fileID: 878382150}
+  - component: {fileID: 878382149}
+  - component: {fileID: 878382148}
   m_Layer: 5
   m_Name: Description
   m_TagString: Untagged
@@ -1732,10 +1816,10 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 479835906}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: -152, y: -74}
@@ -1800,10 +1884,10 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 897580453}
-  - 114: {fileID: 897580454}
+  - component: {fileID: 897580453}
+  - component: {fileID: 897580454}
   m_Layer: 5
   m_Name: Drag
   m_TagString: Untagged
@@ -1820,12 +1904,12 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1495978976}
   - {fileID: 1863190594}
   m_Father: {fileID: 1735991412}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
@@ -1984,13 +2068,13 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 100000, guid: e489ac3472ad77e4496ad84b9af2013a, type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 1060318961}
-  - 212: {fileID: 1060318965}
-  - 61: {fileID: 1060318964}
-  - 114: {fileID: 1060318963}
-  - 114: {fileID: 1060318962}
+  - component: {fileID: 1060318961}
+  - component: {fileID: 1060318965}
+  - component: {fileID: 1060318964}
+  - component: {fileID: 1060318963}
+  - component: {fileID: 1060318962}
   m_Layer: 0
   m_Name: Unity_Logo
   m_TagString: Untagged
@@ -2007,10 +2091,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -9, y: -22.1, z: 0}
   m_LocalScale: {x: 3, y: 3, z: 3}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 2096873804}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1060318962
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2028,13 +2112,12 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
+  basicEditor: 1
   generalProps: 0
   limitsProps: 0
   advancedProps: 0
   minPointers: 0
   maxPointers: 0
-  combinePointers: 0
-  combinePointersInterval: 0.3
   useSendMessage: 0
   sendStateChangeMessages: 0
   sendMessageTarget: {fileID: 0}
@@ -2050,6 +2133,8 @@ MonoBehaviour:
   numberOfTapsRequired: 1
   timeLimit: Infinity
   distanceLimit: Infinity
+  combinePointers: 0
+  combinePointersInterval: 0.3
 --- !u!114 &1060318963
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2074,9 +2159,20 @@ BoxCollider2D:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_UsedByEffector: 0
+  m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2.56, y: 2.56}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
   serializedVersion: 2
   m_Size: {x: 2, y: 2}
+  m_EdgeRadius: 0
 --- !u!212 &1060318965
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -2087,27 +2183,38 @@ SpriteRenderer:
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000e000000000000000, type: 0}
-  m_SubsetIndices: 
-  m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_SelectedEditorRenderState: 0
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 533b9df4691d947d9921a0053b5ce231, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
 --- !u!1001 &1140734431
 Prefab:
   m_ObjectHideFlags: 0
@@ -2155,13 +2262,13 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 119514, guid: 4af91eff6c67b4995be4765a62f7eb5d, type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 1164346782}
-  - 33: {fileID: 1164346786}
-  - 23: {fileID: 1164346785}
-  - 114: {fileID: 1164346784}
-  - 114: {fileID: 1164346783}
+  - component: {fileID: 1164346782}
+  - component: {fileID: 1164346786}
+  - component: {fileID: 1164346785}
+  - component: {fileID: 1164346784}
+  - component: {fileID: 1164346783}
   m_Layer: 0
   m_Name: Board
   m_TagString: Untagged
@@ -2178,12 +2285,12 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.1}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 269580356}
   - {fileID: 750573663}
   m_Father: {fileID: 2041906756}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1164346783
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2201,13 +2308,12 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
+  basicEditor: 1
   generalProps: 0
   limitsProps: 0
   advancedProps: 0
   minPointers: 0
   maxPointers: 0
-  combinePointers: 0
-  combinePointersInterval: 0.3
   useSendMessage: 0
   sendStateChangeMessages: 0
   sendMessageTarget: {fileID: 0}
@@ -2257,22 +2363,28 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: c39504b52f7f64f26b5762f1bb63f09c, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 0
-  m_ReflectionProbeUsage: 1
   m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1164346786
 MeshFilter:
@@ -2455,9 +2567,9 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 1212863163}
+  - component: {fileID: 1212863163}
   m_Layer: 0
   m_Name: Container
   m_TagString: Untagged
@@ -2474,7 +2586,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 151770227}
   - {fileID: 96602513}
@@ -2494,6 +2605,7 @@ Transform:
   - {fileID: 586582585}
   m_Father: {fileID: 1388179442}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1240957464
 Prefab:
   m_ObjectHideFlags: 0
@@ -2541,11 +2653,11 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 1266638325}
-  - 222: {fileID: 1266638327}
-  - 114: {fileID: 1266638326}
+  - component: {fileID: 1266638325}
+  - component: {fileID: 1266638327}
+  - component: {fileID: 1266638326}
   m_Layer: 5
   m_Name: Image
   m_TagString: Untagged
@@ -2562,10 +2674,10 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1622510500}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 31, y: 0}
@@ -2617,9 +2729,9 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 1360329865}
+  - component: {fileID: 1360329865}
   m_Layer: 5
   m_Name: Panel
   m_TagString: Untagged
@@ -2636,11 +2748,11 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1735991412}
   m_Father: {fileID: 479835906}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0.25263783, y: 1}
   m_AnchoredPosition: {x: 5, y: 50}
@@ -2651,13 +2763,13 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 119514, guid: 4af91eff6c67b4995be4765a62f7eb5d, type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 1388179442}
-  - 33: {fileID: 1388179446}
-  - 23: {fileID: 1388179445}
-  - 114: {fileID: 1388179444}
-  - 114: {fileID: 1388179443}
+  - component: {fileID: 1388179442}
+  - component: {fileID: 1388179446}
+  - component: {fileID: 1388179445}
+  - component: {fileID: 1388179444}
+  - component: {fileID: 1388179443}
   m_Layer: 0
   m_Name: Board
   m_TagString: Untagged
@@ -2674,12 +2786,12 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.1}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 519196853}
   - {fileID: 1212863163}
   m_Father: {fileID: 723351974}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1388179443
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2697,13 +2809,12 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
+  basicEditor: 1
   generalProps: 0
   limitsProps: 0
   advancedProps: 0
   minPointers: 0
   maxPointers: 0
-  combinePointers: 0
-  combinePointersInterval: 0.3
   useSendMessage: 0
   sendStateChangeMessages: 0
   sendMessageTarget: {fileID: 0}
@@ -2753,22 +2864,28 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: c39504b52f7f64f26b5762f1bb63f09c, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 0
-  m_ReflectionProbeUsage: 1
   m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &1388179446
 MeshFilter:
@@ -2825,14 +2942,14 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 1416507463}
-  - 20: {fileID: 1416507467}
-  - 124: {fileID: 1416507466}
-  - 92: {fileID: 1416507465}
-  - 81: {fileID: 1416507464}
-  - 114: {fileID: 1416507468}
+  - component: {fileID: 1416507463}
+  - component: {fileID: 1416507467}
+  - component: {fileID: 1416507466}
+  - component: {fileID: 1416507465}
+  - component: {fileID: 1416507464}
+  - component: {fileID: 1416507468}
   m_Layer: 0
   m_Name: 2D Camera
   m_TagString: MainCamera
@@ -2849,10 +2966,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -51.85103}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 655915741}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!81 &1416507464
 AudioListener:
   m_ObjectHideFlags: 0
@@ -2904,6 +3021,8 @@ Camera:
   m_TargetDisplay: 0
   m_TargetEye: 3
   m_HDR: 0
+  m_AllowMSAA: 1
+  m_ForceIntoRT: 0
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
@@ -2920,6 +3039,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Name: 2D Camera
+  basicEditor: 1
   advancedProps: 0
   hitProps: 0
   hit3DObjects: 0
@@ -2943,11 +3063,11 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 1495978976}
-  - 222: {fileID: 1495978978}
-  - 114: {fileID: 1495978977}
+  - component: {fileID: 1495978976}
+  - component: {fileID: 1495978978}
+  - component: {fileID: 1495978977}
   m_Layer: 5
   m_Name: Image
   m_TagString: Untagged
@@ -2964,10 +3084,10 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 897580453}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 31, y: 0}
@@ -3107,10 +3227,10 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 1622510500}
-  - 114: {fileID: 1622510501}
+  - component: {fileID: 1622510500}
+  - component: {fileID: 1622510501}
   m_Layer: 5
   m_Name: Tap
   m_TagString: Untagged
@@ -3127,12 +3247,12 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1266638325}
   - {fileID: 437243916}
   m_Father: {fileID: 1735991412}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
@@ -3215,10 +3335,10 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 1735991412}
-  - 114: {fileID: 1735991411}
+  - component: {fileID: 1735991412}
+  - component: {fileID: 1735991411}
   m_Layer: 5
   m_Name: List
   m_TagString: Untagged
@@ -3246,6 +3366,8 @@ MonoBehaviour:
   m_Spacing: 0
   m_ChildForceExpandWidth: 1
   m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
 --- !u!224 &1735991412
 RectTransform:
   m_ObjectHideFlags: 0
@@ -3255,12 +3377,12 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 897580453}
   - {fileID: 1622510500}
   m_Father: {fileID: 1360329865}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
@@ -3331,10 +3453,10 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 1810922940}
-  - 108: {fileID: 1810922941}
+  - component: {fileID: 1810922940}
+  - component: {fileID: 1810922941}
   m_Layer: 0
   m_Name: Directional light
   m_TagString: Untagged
@@ -3351,10 +3473,10 @@ Transform:
   m_LocalRotation: {x: 0.40821794, y: -0.23456973, z: 0.10938166, w: 0.8754261}
   m_LocalPosition: {x: 0, y: 2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 655915741}
   m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!108 &1810922941
 Light:
   m_ObjectHideFlags: 0
@@ -3362,7 +3484,7 @@ Light:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1810922939}
   m_Enabled: 1
-  serializedVersion: 6
+  serializedVersion: 8
   m_Type: 1
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_Intensity: 1
@@ -3372,6 +3494,7 @@ Light:
   m_Shadows:
     m_Type: 0
     m_Resolution: 3
+    m_CustomResolution: -1
     m_Strength: 0.11
     m_Bias: 0.05
     m_NormalBias: 0.4
@@ -3384,10 +3507,12 @@ Light:
     serializedVersion: 2
     m_Bits: 4294967295
   m_Lightmapping: 1
+  m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
-  m_AreaSize: {x: 1, y: 1}
 --- !u!4 &1828860094 stripped
 Transform:
   m_PrefabParentObject: {fileID: 491238, guid: bb0a05fd2c374477cba1d93212b4600c, type: 2}
@@ -3397,12 +3522,12 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 224: {fileID: 1863190594}
-  - 222: {fileID: 1863190597}
-  - 114: {fileID: 1863190596}
-  - 114: {fileID: 1863190595}
+  - component: {fileID: 1863190594}
+  - component: {fileID: 1863190597}
+  - component: {fileID: 1863190596}
+  - component: {fileID: 1863190595}
   m_Layer: 5
   m_Name: Text
   m_TagString: Untagged
@@ -3419,10 +3544,10 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 897580453}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 177.5, y: 0}
@@ -3570,11 +3695,11 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 1969944223}
-  - 20: {fileID: 1969944224}
-  - 114: {fileID: 1969944225}
+  - component: {fileID: 1969944223}
+  - component: {fileID: 1969944224}
+  - component: {fileID: 1969944225}
   m_Layer: 0
   m_Name: Left 3D Camera
   m_TagString: Untagged
@@ -3591,10 +3716,10 @@ Transform:
   m_LocalRotation: {x: 0.4931347, y: 0.14301865, z: -0.082571894, w: 0.85413456}
   m_LocalPosition: {x: -101.98, y: 10.05, z: -4.74}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 60, y: 19.0112, z: 0}
   m_Children: []
   m_Father: {fileID: 655915741}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 60, y: 19.0112, z: 0}
 --- !u!20 &1969944224
 Camera:
   m_ObjectHideFlags: 0
@@ -3625,6 +3750,8 @@ Camera:
   m_TargetDisplay: 0
   m_TargetEye: 3
   m_HDR: 0
+  m_AllowMSAA: 1
+  m_ForceIntoRT: 0
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
@@ -3641,6 +3768,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Name: Left 3D Camera
+  basicEditor: 1
   advancedProps: 0
   hitProps: 0
   hit3DObjects: 1
@@ -3660,12 +3788,12 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 2041906756}
-  - 114: {fileID: 2041906757}
-  - 114: {fileID: 2041906759}
-  - 114: {fileID: 2041906758}
+  - component: {fileID: 2041906756}
+  - component: {fileID: 2041906757}
+  - component: {fileID: 2041906759}
+  - component: {fileID: 2041906758}
   m_Layer: 0
   m_Name: Left
   m_TagString: Untagged
@@ -3682,11 +3810,11 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -100, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1164346782}
   m_Father: {fileID: 655915741}
   m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2041906757
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3734,13 +3862,12 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: TouchScript.Gestures.Gesture+GestureEvent, Assembly-CSharp, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
+  basicEditor: 1
   generalProps: 0
   limitsProps: 0
   advancedProps: 0
   minPointers: 0
   maxPointers: 0
-  combinePointers: 0
-  combinePointersInterval: 0.3
   useSendMessage: 0
   sendStateChangeMessages: 0
   sendMessageTarget: {fileID: 0}
@@ -3816,9 +3943,9 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 2096873804}
+  - component: {fileID: 2096873804}
   m_Layer: 0
   m_Name: 2D
   m_TagString: Untagged
@@ -3835,13 +3962,13 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 501236165}
   - {fileID: 1060318961}
   - {fileID: 529543779}
   m_Father: {fileID: 655915741}
   m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &2102638578
 Prefab:
   m_ObjectHideFlags: 0

--- a/Source/Assets/TouchScript/Examples/Photos/Photos.unity
+++ b/Source/Assets/TouchScript/Examples/Photos/Photos.unity
@@ -220,7 +220,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7e5768c36d1bb4acea50bd233372843a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Name: Main Camera
+  layerName: 
   basicEditor: 1
   advancedProps: 0
   hitProps: 0
@@ -1987,34 +1987,6 @@ Prefab:
     m_Modifications:
     - target: {fileID: 11400000, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
       propertyPath: layers.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}

--- a/Source/Assets/TouchScript/Examples/Portal/Portal.unity
+++ b/Source/Assets/TouchScript/Examples/Portal/Portal.unity
@@ -489,7 +489,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c6be551879cd14d739b0188844ef2c60, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  debugMode: 0
   OnStateChange:
     m_PersistentCalls:
       m_Calls: []
@@ -1040,7 +1039,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c6be551879cd14d739b0188844ef2c60, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  debugMode: 0
   OnStateChange:
     m_PersistentCalls:
       m_Calls: []
@@ -1341,7 +1339,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c6be551879cd14d739b0188844ef2c60, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  debugMode: 0
   OnStateChange:
     m_PersistentCalls:
       m_Calls: []
@@ -1783,7 +1780,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c6be551879cd14d739b0188844ef2c60, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  debugMode: 0
   OnStateChange:
     m_PersistentCalls:
       m_Calls: []

--- a/Source/Assets/TouchScript/Examples/Portal/Portal.unity
+++ b/Source/Assets/TouchScript/Examples/Portal/Portal.unity
@@ -153,7 +153,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7e5768c36d1bb4acea50bd233372843a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Name: Camera
+  layerName: 
   basicEditor: 1
   advancedProps: 0
   hitProps: 0
@@ -387,34 +387,6 @@ Prefab:
     m_Modifications:
     - target: {fileID: 11400000, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
       propertyPath: layers.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}

--- a/Source/Assets/TouchScript/Examples/Pull/Pull.unity
+++ b/Source/Assets/TouchScript/Examples/Pull/Pull.unity
@@ -256,7 +256,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7e5768c36d1bb4acea50bd233372843a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Name: Scene Camera
+  layerName: 
   basicEditor: 1
   advancedProps: 0
   hitProps: 0
@@ -536,34 +536,6 @@ Prefab:
     m_Modifications:
     - target: {fileID: 11400000, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
       propertyPath: layers.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}

--- a/Source/Assets/TouchScript/Examples/RawInput/RawInput.unity
+++ b/Source/Assets/TouchScript/Examples/RawInput/RawInput.unity
@@ -279,34 +279,6 @@ Prefab:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}

--- a/Source/Assets/TouchScript/Examples/Taps/Taps.unity
+++ b/Source/Assets/TouchScript/Examples/Taps/Taps.unity
@@ -152,7 +152,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7e5768c36d1bb4acea50bd233372843a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Name: Scene Camera
+  layerName: 
   basicEditor: 1
   advancedProps: 0
   hitProps: 0
@@ -457,34 +457,6 @@ Prefab:
     m_Modifications:
     - target: {fileID: 11400000, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
       propertyPath: layers.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}
-      propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: 1c4dd8a13f501b04f84fe824120f70bb, type: 2}

--- a/Source/Assets/TouchScript/Modules/TUIO/Scripts/InputSources/TuioInput.cs
+++ b/Source/Assets/TouchScript/Modules/TUIO/Scripts/InputSources/TuioInput.cs
@@ -96,8 +96,6 @@ namespace TouchScript.InputSources
         private Dictionary<TuioCursor, TouchPointer> cursorToInternalId = new Dictionary<TuioCursor, TouchPointer>(10);
         private Dictionary<TuioBlob, ObjectPointer> blobToInternalId = new Dictionary<TuioBlob, ObjectPointer>();
         private Dictionary<TuioObject, ObjectPointer> objectToInternalId = new Dictionary<TuioObject, ObjectPointer>();
-        private int screenWidth;
-        private int screenHeight;
 
         private ObjectPool<TouchPointer> touchPool;
         private ObjectPool<ObjectPointer> objectPool;
@@ -115,17 +113,6 @@ namespace TouchScript.InputSources
         #endregion
 
         #region Public methods
-
-        /// <inheritdoc />
-        public override bool UpdateInput()
-        {
-            if (base.UpdateInput()) return true;
-
-            screenWidth = Screen.width;
-            screenHeight = Screen.height;
-
-            return true;
-        }
 
         /// <inheritdoc />
         public override bool CancelPointer(Pointer pointer, bool shouldReturn)
@@ -232,13 +219,19 @@ namespace TouchScript.InputSources
         #region Unity
 
         /// <inheritdoc />
-        protected override void OnEnable()
+        protected override void OnDisable()
         {
-            base.OnEnable();
+            disconnect();
+            base.OnDisable();
+        }
 
-            screenWidth = Screen.width;
-            screenHeight = Screen.height;
+        #endregion
 
+        #region Protected methods
+
+        /// <inheritdoc />
+        protected override void init()
+        {
             cursorProcessor = new CursorProcessor();
             cursorProcessor.CursorAdded += OnCursorAdded;
             cursorProcessor.CursorUpdated += OnCursorUpdated;
@@ -255,13 +248,6 @@ namespace TouchScript.InputSources
             objectProcessor.ObjectRemoved += OnObjectRemoved;
 
             connect();
-        }
-
-        /// <inheritdoc />
-        protected override void OnDisable()
-        {
-            disconnect();
-            base.OnDisable();
         }
 
         #endregion

--- a/Source/Assets/TouchScript/Prefabs/TouchManager.prefab
+++ b/Source/Assets/TouchScript/Prefabs/TouchManager.prefab
@@ -41,7 +41,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0dd4c394fe06f4ea49e03aaa5e7a8190, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  debugMode: 1
   OnFrameStart:
     m_PersistentCalls:
       m_Calls: []
@@ -82,12 +81,12 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
-  advancedProps: 0
+  basicEditor: 1
   displayDevice: {fileID: 0}
   shouldCreateCameraLayer: 1
   shouldCreateStandardInput: 1
   useSendMessage: 0
-  sendMessageEvents: 60
+  sendMessageEvents: 252
   sendMessageTarget: {fileID: 0}
   useUnityEvents: 0
   layers: []
@@ -102,9 +101,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e276ccba4f7314d9988af19f9b3a611b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  advancedProps: 0
+  basicEditor: 1
   generalProps: 0
   windowsProps: 0
+  webglProps: 0
   windows8API: 0
   windows7API: 0
   webGLTouch: 1

--- a/Source/Assets/TouchScript/Scripts/Behaviors/Cursors/CursorManager.cs
+++ b/Source/Assets/TouchScript/Scripts/Behaviors/Cursors/CursorManager.cs
@@ -169,28 +169,28 @@ namespace TouchScript.Behaviors.Cursors
 
         private void OnEnable()
         {
-            if (TouchManager.Instance != null)
-            {
-                TouchManager.Instance.PointersAdded += pointersAddedHandler;
-                TouchManager.Instance.PointersRemoved += pointersRemovedHandler;
-                TouchManager.Instance.PointersPressed += pointersPressedHandler;
-                TouchManager.Instance.PointersReleased += pointersReleasedHandler;
-                TouchManager.Instance.PointersUpdated += PointersUpdatedHandler;
-                TouchManager.Instance.PointersCancelled += pointersCancelledHandler;
-            }
+            var touchManager = TouchManager.Instance;
+            if (touchManager == null) return;
+
+            touchManager.PointersAdded += pointersAddedHandler;
+            touchManager.PointersRemoved += pointersRemovedHandler;
+            touchManager.PointersPressed += pointersPressedHandler;
+            touchManager.PointersReleased += pointersReleasedHandler;
+            touchManager.PointersUpdated += PointersUpdatedHandler;
+            touchManager.PointersCancelled += pointersCancelledHandler;
         }
 
         private void OnDisable()
         {
-            if (TouchManager.Instance != null)
-            {
-                TouchManager.Instance.PointersAdded -= pointersAddedHandler;
-                TouchManager.Instance.PointersRemoved -= pointersRemovedHandler;
-                TouchManager.Instance.PointersPressed -= pointersPressedHandler;
-                TouchManager.Instance.PointersReleased -= pointersReleasedHandler;
-                TouchManager.Instance.PointersUpdated -= PointersUpdatedHandler;
-                TouchManager.Instance.PointersCancelled -= pointersCancelledHandler;
-            }
+            var touchManager = TouchManager.Instance;
+            if (touchManager == null) return;
+
+            touchManager.PointersAdded -= pointersAddedHandler;
+            touchManager.PointersRemoved -= pointersRemovedHandler;
+            touchManager.PointersPressed -= pointersPressedHandler;
+            touchManager.PointersReleased -= pointersReleasedHandler;
+            touchManager.PointersUpdated -= PointersUpdatedHandler;
+            touchManager.PointersCancelled -= pointersCancelledHandler;
         }
 
         #endregion

--- a/Source/Assets/TouchScript/Scripts/Behaviors/Transformer.cs
+++ b/Source/Assets/TouchScript/Scripts/Behaviors/Transformer.cs
@@ -175,7 +175,8 @@ namespace TouchScript.Behaviors
         {
             gesture = GetComponent<TransformGestureBase>();
             gesture.StateChanged += stateChangedHandler;
-            TouchManager.Instance.FrameFinished += frameFinishedHandler;
+            var touchManager = TouchManager.Instance;
+            if (touchManager != null) touchManager.FrameFinished += frameFinishedHandler;
 
             stateIdle();
         }
@@ -183,8 +184,8 @@ namespace TouchScript.Behaviors
         private void OnDisable()
         {
             if (gesture != null) gesture.StateChanged -= stateChangedHandler;
-            if (TouchManager.Instance != null)
-                TouchManager.Instance.FrameFinished -= frameFinishedHandler;
+            var touchManager = TouchManager.Instance;
+            if (touchManager != null) touchManager.FrameFinished -= frameFinishedHandler;
 
             stateIdle();
         }

--- a/Source/Assets/TouchScript/Scripts/Behaviors/UI/OverHelper.cs
+++ b/Source/Assets/TouchScript/Scripts/Behaviors/UI/OverHelper.cs
@@ -43,21 +43,26 @@ namespace TouchScript.Behaviors.UI
 
         private void OnEnable()
         {
-            TouchManager.Instance.PointersAdded += pointersAddedHandler;
-            TouchManager.Instance.PointersUpdated += pointersUpdatedHandler;
-            TouchManager.Instance.PointersReleased += pointersReleasedHandler;
-            TouchManager.Instance.PointersRemoved += pointersRemovedHandler;
-            TouchManager.Instance.PointersCancelled += pointersRemovedHandler;
+            var touchManager = TouchManager.Instance;
+            if (touchManager == null) return;
+
+            touchManager.PointersAdded += pointersAddedHandler;
+            touchManager.PointersUpdated += pointersUpdatedHandler;
+            touchManager.PointersReleased += pointersReleasedHandler;
+            touchManager.PointersRemoved += pointersRemovedHandler;
+            touchManager.PointersCancelled += pointersRemovedHandler;
         }
 
         private void OnDisable()
         {
-			if (TouchManager.Instance == null) return;
-            TouchManager.Instance.PointersAdded -= pointersAddedHandler;
-            TouchManager.Instance.PointersUpdated -= pointersUpdatedHandler;
-            TouchManager.Instance.PointersReleased -= pointersReleasedHandler;
-            TouchManager.Instance.PointersRemoved -= pointersRemovedHandler;
-            TouchManager.Instance.PointersCancelled -= pointersRemovedHandler;
+            var touchManager = TouchManager.Instance;
+            if (touchManager == null) return;
+
+            touchManager.PointersAdded -= pointersAddedHandler;
+            touchManager.PointersUpdated -= pointersUpdatedHandler;
+            touchManager.PointersReleased -= pointersReleasedHandler;
+            touchManager.PointersRemoved -= pointersRemovedHandler;
+            touchManager.PointersCancelled -= pointersRemovedHandler;
         }
 
         #endregion

--- a/Source/Assets/TouchScript/Scripts/Core/GestureManagerInstance.cs
+++ b/Source/Assets/TouchScript/Scripts/Core/GestureManagerInstance.cs
@@ -26,9 +26,11 @@ namespace TouchScript.Core
         {
             get
             {
-                if (shuttingDown) return null;
-                if (instance == null)
+                if (object.Equals(instance, null))
                 {
+                    // Create an instance if it hasn't been created yet.
+                    // Don't recreate it if the instance was destroyed. 
+                    // Should happen only when the app is closing or editor is exiting Play Mode.
                     if (!Application.isPlaying) return null;
                     var objects = FindObjectsOfType<GestureManagerInstance>();
                     if (objects.Length == 0)
@@ -53,7 +55,6 @@ namespace TouchScript.Core
         #region Private variables
 
         private static GestureManagerInstance instance;
-        private static bool shuttingDown = false;
 
         // Upcoming changes
         private List<Gesture> gesturesToReset = new List<Gesture>(20);
@@ -121,34 +122,27 @@ namespace TouchScript.Core
         private void OnEnable()
         {
             var touchManager = TouchManager.Instance;
-            if (touchManager != null)
-            {
-                touchManager.FrameStarted += frameStartedHandler;
-                touchManager.FrameFinished += frameFinishedHandler;
-                touchManager.PointersUpdated += pointersUpdatedHandler;
-                touchManager.PointersPressed += pointersPressedHandler;
-                touchManager.PointersReleased += pointersReleasedHandler;
-                touchManager.PointersCancelled += pointersCancelledHandler;
-            }
+            if (touchManager == null) return;
+
+            touchManager.FrameStarted += frameStartedHandler;
+            touchManager.FrameFinished += frameFinishedHandler;
+            touchManager.PointersUpdated += pointersUpdatedHandler;
+            touchManager.PointersPressed += pointersPressedHandler;
+            touchManager.PointersReleased += pointersReleasedHandler;
+            touchManager.PointersCancelled += pointersCancelledHandler;
         }
 
         private void OnDisable()
         {
             var touchManager = TouchManager.Instance;
-            if (touchManager != null)
-            {
-                touchManager.FrameStarted -= frameStartedHandler;
-                touchManager.FrameFinished -= frameFinishedHandler;
-                touchManager.PointersUpdated -= pointersUpdatedHandler;
-                touchManager.PointersPressed -= pointersPressedHandler;
-                touchManager.PointersReleased -= pointersReleasedHandler;
-                touchManager.PointersCancelled -= pointersCancelledHandler;
-            }
-        }
+            if (touchManager == null) return;
 
-        private void OnApplicationQuit()
-        {
-            shuttingDown = true;
+            touchManager.FrameStarted -= frameStartedHandler;
+            touchManager.FrameFinished -= frameFinishedHandler;
+            touchManager.PointersUpdated -= pointersUpdatedHandler;
+            touchManager.PointersPressed -= pointersPressedHandler;
+            touchManager.PointersReleased -= pointersReleasedHandler;
+            touchManager.PointersCancelled -= pointersCancelledHandler;
         }
 
         #endregion

--- a/Source/Assets/TouchScript/Scripts/Core/GestureManagerInstance.cs
+++ b/Source/Assets/TouchScript/Scripts/Core/GestureManagerInstance.cs
@@ -83,13 +83,13 @@ namespace TouchScript.Core
         #region Pools
 
         private static ObjectPool<List<Gesture>> gestureListPool = new ObjectPool<List<Gesture>>(10,
-            () => new List<Gesture>(10), null, (l) => l.Clear(), "GestureManager/Gesture");
+            () => new List<Gesture>(10), null, (l) => l.Clear());
 
         private static ObjectPool<List<Pointer>> pointerListPool = new ObjectPool<List<Pointer>>(20,
-            () => new List<Pointer>(10), null, (l) => l.Clear(), "GestureManager/Pointer");
+            () => new List<Pointer>(10), null, (l) => l.Clear());
 
         private static ObjectPool<List<Transform>> transformListPool = new ObjectPool<List<Transform>>(10,
-            () => new List<Transform>(10), null, (l) => l.Clear(), "GestureManager/Transform");
+            () => new List<Transform>(10), null, (l) => l.Clear());
 
         #endregion
 

--- a/Source/Assets/TouchScript/Scripts/Core/TouchManagerInstance.cs
+++ b/Source/Assets/TouchScript/Scripts/Core/TouchManagerInstance.cs
@@ -103,9 +103,11 @@ namespace TouchScript.Core
         {
             get
             {
-                if (shuttingDown) return null;
-                if (instance == null)
+                if (object.Equals(instance, null))
                 {
+                    // Create an instance if it hasn't been created yet.
+                    // Don't recreate it if the instance was destroyed. 
+                    // Should happen only when the app is closing or editor is exiting Play Mode.
                     if (!Application.isPlaying) return null;
                     var objects = FindObjectsOfType<TouchManagerInstance>();
                     if (objects.Length == 0)
@@ -210,7 +212,6 @@ namespace TouchScript.Core
 
         #region Private variables
 
-        private static bool shuttingDown = false;
         private static TouchManagerInstance instance;
 
         private bool shouldCreateCameraLayer = true;
@@ -582,18 +583,13 @@ namespace TouchScript.Core
             updatePointers();
         }
 
-        private void OnApplicationQuit()
-        {
-            shuttingDown = true;
-        }
-
         #endregion
 
         #region Private functions
 
         private void createCameraLayer()
         {
-            if (layerManager.LayerCount == 0 && shouldCreateCameraLayer)
+            if (layerManager != null && layerManager.LayerCount == 0 && shouldCreateCameraLayer)
             {
                 if (Camera.main != null)
                 {

--- a/Source/Assets/TouchScript/Scripts/Core/TouchManagerInstance.cs
+++ b/Source/Assets/TouchScript/Scripts/Core/TouchManagerInstance.cs
@@ -297,7 +297,7 @@ namespace TouchScript.Core
             Pointer pointer;
             if (idToPointer.TryGetValue(id, out pointer))
             {
-                pointer.InputSource.CancelPointer(pointer, shouldReturn);
+                if (pointer.InputSource != null) pointer.InputSource.CancelPointer(pointer, shouldReturn);
             }
         }
 
@@ -877,7 +877,7 @@ namespace TouchScript.Core
             for (var i = 0; i < removedCount; i++)
             {
                 var pointer = list[i];
-                pointer.InputSource.INTERNAL_DiscardPointer(pointer);
+                if (pointer.InputSource != null) pointer.InputSource.INTERNAL_DiscardPointer(pointer);
             }
             pointerListPool.Release(list);
 
@@ -937,7 +937,7 @@ namespace TouchScript.Core
             for (var i = 0; i < cancelledCount; i++)
             {
                 var pointer = list[i];
-                pointer.InputSource.INTERNAL_DiscardPointer(pointer);
+                if (pointer.InputSource != null) pointer.InputSource.INTERNAL_DiscardPointer(pointer);
             }
             pointerListPool.Release(list);
 

--- a/Source/Assets/TouchScript/Scripts/Core/TouchManagerInstance.cs
+++ b/Source/Assets/TouchScript/Scripts/Core/TouchManagerInstance.cs
@@ -145,7 +145,7 @@ namespace TouchScript.Core
                 {
                     displayDevice = value;
                 }
-                UpdateResolution();
+                updateDPI();
             }
         }
 
@@ -308,8 +308,7 @@ namespace TouchScript.Core
             CancelPointer(id, false);
         }
 
-        /// <inheritdoc />
-        public void UpdateResolution()
+        private void updateDPI()
         {
             if (DisplayDevice != null)
             {
@@ -324,8 +323,12 @@ namespace TouchScript.Core
 #if TOUCHSCRIPT_DEBUG
             debugPointerSize = Vector2.one * dotsPerCentimeter;
 #endif
-            
-            foreach (var input in inputs) input.UpdateResolution();
+        }
+
+        /// <inheritdoc />
+        public void UpdateResolution()
+        {
+            foreach (var input in inputs) input.INTERNAL_UpdateResolution();
         }
 
         #endregion
@@ -524,8 +527,7 @@ namespace TouchScript.Core
             DontDestroyOnLoad(gameObject);
 
             layerManager = LayerManager.Instance;
-
-            UpdateResolution();
+            updateDPI();
 
             StopAllCoroutines();
             StartCoroutine(lateAwake());

--- a/Source/Assets/TouchScript/Scripts/Debugging/TouchScriptDebugger.cs
+++ b/Source/Assets/TouchScript/Scripts/Debugging/TouchScriptDebugger.cs
@@ -58,10 +58,11 @@ namespace TouchScript.Debugging
 
         public void ClearPointerLogger()
         {
-            if (Application.isEditor)
-                pointerLogger = new DummyLogger();
-            else
-                pointerLogger = new FileWriterLogger();
+            pointerLogger = new DummyLogger();
+//            if (Application.isEditor)
+//                pointerLogger = new DummyLogger();
+//            else
+//                pointerLogger = new FileWriterLogger();
         }
 
         private void OnEnable()

--- a/Source/Assets/TouchScript/Scripts/Gestures/TransformGestures/ITransformGesture.cs
+++ b/Source/Assets/TouchScript/Scripts/Gestures/TransformGestures/ITransformGesture.cs
@@ -25,6 +25,7 @@ namespace TouchScript.Gestures.TransformGestures
 
         /// <summary>
         /// Occurs when gesture finishes.
+        /// Note that all transformation deltas are zero during this event. To get up-to-date deltas please subscribe to <see cref="Transformed"/> event.
         /// </summary>
         event EventHandler<EventArgs> TransformCompleted;
 

--- a/Source/Assets/TouchScript/Scripts/InputSources/IInputSource.cs
+++ b/Source/Assets/TouchScript/Scripts/InputSources/IInputSource.cs
@@ -2,7 +2,6 @@
  * @author Valentin Simonov / http://va.lent.in/
  */
 
-using TouchScript.Core;
 using TouchScript.Pointers;
 
 namespace TouchScript.InputSources
@@ -14,7 +13,48 @@ namespace TouchScript.InputSources
     /// <para>In TouchScript all pointer points (<see cref="Pointer"/>) come from input sources.</para>
     /// <para>If you want to feed pointers to the library the best way to do it is to create a custom input source.</para>
     /// </remarks>
-    public interface IInputSource : INTERNAL_IInputSource
+    public interface IInputSource : IInputSourceLike, INTERNAL_IInputSource
+    {
+    }
+
+    /// <summary>
+    /// Internal methods for <see cref="IInputSource"/>. DO NOT CALL THESE METHODS DIRECTLY FROM YOUR CODE!
+    /// </summary>
+    public interface INTERNAL_IInputSource
+    {
+        /// <summary>
+        /// Used by <see cref="TouchManagerInstance"/> to return a pointer to input source.
+        /// DO NOT CALL THIS METHOD DIRECTLY FROM YOUR CODE!
+        /// </summary>
+        /// <param name="pointer">The pointer.</param>
+        void INTERNAL_DiscardPointer(Pointer pointer);
+
+        /// <summary>
+        /// Used by <see cref="TouchManagerInstance"/> to return sync resolution on inputs.
+        /// DO NOT CALL THIS METHOD DIRECTLY FROM YOUR CODE!
+        /// </summary>
+        void INTERNAL_UpdateResolution();
+    }
+
+    /// <summary>
+    /// An object which is used by an <see cref="IInputSource"/> to capture input from a device but is not itself an <see cref="IInputSource"/>,
+    /// </summary>
+    public interface IInputHandler : IInputSourceLike
+    {
+        /// <summary>
+        /// Returns a pointer to the handler.
+        /// </summary>
+        /// <param name="pointer">The pointer.</param>
+        /// <returns><c>True</c> if the pointer was handled by the object; <c>false</c> otherwise.</returns>
+        bool DiscardPointer(Pointer pointer);
+
+        /// <summary>
+        /// Updates resolution.
+        /// </summary>
+        void UpdateResolution(int width, int height);
+    }
+
+    public interface IInputSourceLike
     {
         /// <summary>
         /// Gets or sets current coordinates remapper.
@@ -25,12 +65,8 @@ namespace TouchScript.InputSources
         /// <summary>
         /// This method is called by <see cref="ITouchManager"/> to synchronously update the input.
         /// </summary>
+        /// <returns><c>True</c> if the input source was updated; <c>false</c> otherwise.</returns>
         bool UpdateInput();
-
-        /// <summary>
-        /// Forces the input to update its state when resolution changes.
-        /// </summary>
-        void UpdateResolution();
 
         /// <summary>
         /// Cancels the pointer.
@@ -41,16 +77,4 @@ namespace TouchScript.InputSources
         bool CancelPointer(Pointer pointer, bool shouldReturn);
     }
 
-    /// <summary>
-    /// Internal methods for <see cref="IInputSource"/>. DO NOT USE ANY OF THEM!
-    /// </summary>
-    public interface INTERNAL_IInputSource
-    {
-        /// <summary>
-        /// Used by <see cref="TouchManagerInstance"/> to return a pointer to input source.
-        /// DO NOT CALL IT DIRECTLY FROM YOUR CODE!
-        /// </summary>
-        /// <param name="pointer">The pointer.</param>
-        void INTERNAL_DiscardPointer(Pointer pointer);
-    }
 }

--- a/Source/Assets/TouchScript/Scripts/InputSources/InputHandlers/MouseHandler.cs
+++ b/Source/Assets/TouchScript/Scripts/InputSources/InputHandlers/MouseHandler.cs
@@ -217,7 +217,15 @@ namespace TouchScript.InputSources.InputHandlers
                         break;
                     case State.StationaryFake:
                         if (buttons != newButtons) updateButtons(buttons, newButtons);
-                        if (fakeTouchReleased())
+						if ((newButtons & Pointer.PointerButtonState.AnyButtonPressed) != 0)
+						{
+							if (Input.GetKey(KeyCode.LeftControl) && mousePointPos != pos)
+							{
+								fakeMousePointer.Position += (remappedPos - mousePointer.Position);
+								updatePointer(fakeMousePointer);
+							}
+						}
+						if (fakeTouchReleased())
                         {
                             stateMouse();
                         }

--- a/Source/Assets/TouchScript/Scripts/InputSources/InputHandlers/MouseHandler.cs
+++ b/Source/Assets/TouchScript/Scripts/InputSources/InputHandlers/MouseHandler.cs
@@ -103,7 +103,7 @@ namespace TouchScript.InputSources.InputHandlers
             this.removePointer = removePointer;
             this.cancelPointer = cancelPointer;
 
-            mousePool = new ObjectPool<MousePointer>(4, () => new MousePointer(input), null, resetPointer);
+            mousePool = new ObjectPool<MousePointer>(4, newPointer, null, resetPointer);
 
             mousePointPos = Input.mousePosition;
             mousePointer = internalAddPointer(remapCoordinates(mousePointPos));
@@ -422,6 +422,11 @@ namespace TouchScript.InputSources.InputHandlers
         private void resetPointer(Pointer p)
         {
             p.INTERNAL_Reset();
+        }
+
+        private MousePointer newPointer()
+        {
+            return new MousePointer(input);
         }
 
         #endregion

--- a/Source/Assets/TouchScript/Scripts/InputSources/InputHandlers/MouseHandler.cs
+++ b/Source/Assets/TouchScript/Scripts/InputSources/InputHandlers/MouseHandler.cs
@@ -219,10 +219,18 @@ namespace TouchScript.InputSources.InputHandlers
                         if (buttons != newButtons) updateButtons(buttons, newButtons);
                         if ((newButtons & Pointer.PointerButtonState.AnyButtonPressed) != 0)
                         {
-                            if (Input.GetKey(KeyCode.LeftControl) && mousePointPos != pos)
+                            if (mousePointPos != pos)
                             {
-                                fakeMousePointer.Position += (remappedPos - mousePointer.Position);
-                                updatePointer(fakeMousePointer);
+                                if (Input.GetKey(KeyCode.LeftControl))
+                                {
+                                    fakeMousePointer.Position += (remappedPos - mousePointer.Position);
+                                    updatePointer(fakeMousePointer);
+                                }
+                                else if (Input.GetKey(KeyCode.LeftShift))
+                                {
+                                    fakeMousePointer.Position -= (remappedPos - mousePointer.Position);
+                                    updatePointer(fakeMousePointer);
+                                }
                             }
                         }
                         if (fakeTouchReleased())

--- a/Source/Assets/TouchScript/Scripts/InputSources/InputHandlers/MouseHandler.cs
+++ b/Source/Assets/TouchScript/Scripts/InputSources/InputHandlers/MouseHandler.cs
@@ -217,15 +217,15 @@ namespace TouchScript.InputSources.InputHandlers
                         break;
                     case State.StationaryFake:
                         if (buttons != newButtons) updateButtons(buttons, newButtons);
-						if ((newButtons & Pointer.PointerButtonState.AnyButtonPressed) != 0)
-						{
-							if (Input.GetKey(KeyCode.LeftControl) && mousePointPos != pos)
-							{
-								fakeMousePointer.Position += (remappedPos - mousePointer.Position);
-								updatePointer(fakeMousePointer);
-							}
-						}
-						if (fakeTouchReleased())
+                        if ((newButtons & Pointer.PointerButtonState.AnyButtonPressed) != 0)
+                        {
+                            if (Input.GetKey(KeyCode.LeftControl) && mousePointPos != pos)
+                            {
+                                fakeMousePointer.Position += (remappedPos - mousePointer.Position);
+                                updatePointer(fakeMousePointer);
+                            }
+                        }
+                        if (fakeTouchReleased())
                         {
                             stateMouse();
                         }

--- a/Source/Assets/TouchScript/Scripts/InputSources/InputHandlers/MouseHandler.cs
+++ b/Source/Assets/TouchScript/Scripts/InputSources/InputHandlers/MouseHandler.cs
@@ -256,7 +256,8 @@ namespace TouchScript.InputSources.InputHandlers
         /// <inheritdoc />
         public void UpdateResolution()
         {
-            TouchManager.Instance.CancelPointer(mousePointer.Id);
+            var touchManager = TouchManager.Instance;
+            if (touchManager != null) touchManager.CancelPointer(mousePointer.Id);
         }
 
         /// <inheritdoc />

--- a/Source/Assets/TouchScript/Scripts/InputSources/InputHandlers/TouchHandler.cs
+++ b/Source/Assets/TouchScript/Scripts/InputSources/InputHandlers/TouchHandler.cs
@@ -74,7 +74,7 @@ namespace TouchScript.InputSources.InputHandlers
             this.removePointer = removePointer;
             this.cancelPointer = cancelPointer;
 
-            touchPool = new ObjectPool<TouchPointer>(10, () => new TouchPointer(input), null, resetPointer, "TouchHandler/Touch");
+            touchPool = new ObjectPool<TouchPointer>(10, newPointer, null, resetPointer, "TouchHandler/Touch");
             touchPool.Name = "Touch";
 
 #if UNITY_5_6_OR_NEWER
@@ -272,6 +272,11 @@ namespace TouchScript.InputSources.InputHandlers
         private void resetPointer(Pointer p)
         {
             p.INTERNAL_Reset();
+        }
+
+        private TouchPointer newPointer()
+        {
+            return new TouchPointer(input);
         }
 
         #endregion

--- a/Source/Assets/TouchScript/Scripts/InputSources/InputHandlers/TouchHandler.cs
+++ b/Source/Assets/TouchScript/Scripts/InputSources/InputHandlers/TouchHandler.cs
@@ -115,7 +115,7 @@ namespace TouchScript.InputSources.InputHandlers
                         {
                             if (touchState.Phase != TouchPhase.Canceled)
                             {
-                                touchState.Pointer.Position = t.position;
+                                touchState.Pointer.Position = remapCoordinates(t.position);
                                 updatePointer(touchState.Pointer);
                             }
                         }

--- a/Source/Assets/TouchScript/Scripts/InputSources/InputHandlers/TouchHandler.cs
+++ b/Source/Assets/TouchScript/Scripts/InputSources/InputHandlers/TouchHandler.cs
@@ -75,7 +75,7 @@ namespace TouchScript.InputSources.InputHandlers
             touchPool.Name = "Touch";
 
 #if UNITY_5_6_OR_NEWER
-			updateSampler = CustomSampler.Create("[TouchScript] Update touch");
+			updateSampler = CustomSampler.Create("[TouchScript] Update Touch");
 #endif
         }
 

--- a/Source/Assets/TouchScript/Scripts/InputSources/InputHandlers/WindowsPointerHandlers.cs
+++ b/Source/Assets/TouchScript/Scripts/InputSources/InputHandlers/WindowsPointerHandlers.cs
@@ -65,8 +65,8 @@ namespace TouchScript.InputSources.InputHandlers
         /// <inheritdoc />
         public Windows8PointerHandler(IInputSource input, PointerDelegate addPointer, PointerDelegate updatePointer, PointerDelegate pressPointer, PointerDelegate releasePointer, PointerDelegate removePointer, PointerDelegate cancelPointer) : base(input, addPointer, updatePointer, pressPointer, releasePointer, removePointer, cancelPointer)
         {
-            mousePool = new ObjectPool<MousePointer>(4, () => new MousePointer(input), null, resetPointer);
-            penPool = new ObjectPool<PenPointer>(2, () => new PenPointer(input), null, resetPointer);
+            mousePool = new ObjectPool<MousePointer>(4, newMousePointer, null, resetPointer);
+            penPool = new ObjectPool<PenPointer>(2, newPenPointer, null, resetPointer);
 
             mousePointer = internalAddMousePointer(Vector3.zero);
 
@@ -130,6 +130,20 @@ namespace TouchScript.InputSources.InputHandlers
             WindowsUtils.EnableMouseInPointer(false);
 
             base.Dispose();
+        }
+
+        #endregion
+
+        #region Private functions
+
+        private MousePointer newMousePointer()
+        {
+            return new MousePointer(input);
+        }
+
+        private PenPointer newPenPointer()
+        {
+            return new PenPointer(input);
         }
 
         #endregion
@@ -242,7 +256,7 @@ namespace TouchScript.InputSources.InputHandlers
             nativeLogDelegate = nativeLog;
             nativePointerDelegate = nativePointer;
 
-            touchPool = new ObjectPool<TouchPointer>(10, () => new TouchPointer(input), null, resetPointer);
+            touchPool = new ObjectPool<TouchPointer>(10, newTouchPointer, null, resetPointer);
 
             hMainWindow = WindowsUtils.GetActiveWindow();
             disablePressAndHold();
@@ -451,6 +465,11 @@ namespace TouchScript.InputSources.InputHandlers
             WindowsUtils.GetNativeMonitorResolution(out width, out height);
             float scale = Mathf.Max(screenWidth / ((float) width), screenHeight / ((float) height));
             SetScreenParams(screenWidth, screenHeight, (width - screenWidth / scale) * .5f, (height - screenHeight / scale) * .5f, scale, scale);
+        }
+
+        private TouchPointer newTouchPointer()
+        {
+            return new TouchPointer(input);
         }
 
         #endregion

--- a/Source/Assets/TouchScript/Scripts/InputSources/InputHandlers/WindowsPointerHandlers.cs
+++ b/Source/Assets/TouchScript/Scripts/InputSources/InputHandlers/WindowsPointerHandlers.cs
@@ -503,7 +503,7 @@ namespace TouchScript.InputSources.InputHandlers
                             releasePointer(mousePointer);
                             break;
                         case PointerEvent.Update:
-                            mousePointer.Position = position;
+                            mousePointer.Position = remapCoordinates(position);
                             mousePointer.Buttons = updateButtons(mousePointer.Buttons, data.PointerFlags, data.ChangedButtons);
                             updatePointer(mousePointer);
                             break;
@@ -539,7 +539,7 @@ namespace TouchScript.InputSources.InputHandlers
                             break;
                         case PointerEvent.Update:
                             if (!winTouchToInternalId.TryGetValue(id, out touchPointer)) return;
-                            touchPointer.Position = position;
+                            touchPointer.Position = remapCoordinates(position);
                             touchPointer.Rotation = getTouchRotation(ref data);
                             touchPointer.Pressure = getTouchPressure(ref data);
                             updatePointer(touchPointer);
@@ -579,7 +579,7 @@ namespace TouchScript.InputSources.InputHandlers
                             break;
                         case PointerEvent.Update:
                             if (penPointer == null) break;
-                            penPointer.Position = position;
+                            penPointer.Position = remapCoordinates(position);
                             penPointer.Pressure = getPenPressure(ref data);
                             penPointer.Rotation = getPenRotation(ref data);
                             penPointer.Buttons = updateButtons(penPointer.Buttons, data.PointerFlags, data.ChangedButtons);

--- a/Source/Assets/TouchScript/Scripts/InputSources/InputSource.cs
+++ b/Source/Assets/TouchScript/Scripts/InputSources/InputSource.cs
@@ -50,6 +50,9 @@ namespace TouchScript.InputSources
 		private ICoordinatesRemapper coordinatesRemapper;
         private TouchManagerInstance touchManager;
 
+        protected int screenWidth;
+        protected int screenHeight;
+
         #endregion
 
         #region Public methods
@@ -59,9 +62,6 @@ namespace TouchScript.InputSources
         {
             return false;
         }
-
-        /// <inheritdoc />
-        public virtual void UpdateResolution() {}
 
         /// <inheritdoc />
         public virtual bool CancelPointer(Pointer pointer, bool shouldReturn)
@@ -76,6 +76,13 @@ namespace TouchScript.InputSources
         /// <inheritdoc />
         public virtual void INTERNAL_DiscardPointer(Pointer pointer) {}
 
+        /// <inheritdoc />
+        public virtual void INTERNAL_UpdateResolution()
+        {
+            screenWidth = Screen.width;
+            screenHeight = Screen.height;
+        }
+
         #endregion
 
         #region Unity methods
@@ -83,11 +90,15 @@ namespace TouchScript.InputSources
         /// <summary>
         /// Unity OnEnable callback.
         /// </summary>
-        protected virtual void OnEnable()
+        private void OnEnable()
         {
             touchManager = TouchManagerInstance.Instance;
             if (touchManager == null) throw new InvalidOperationException("TouchManager instance is required!");
             touchManager.AddInput(this);
+
+            init();
+
+            INTERNAL_UpdateResolution();
         }
 
         /// <summary>
@@ -105,6 +116,11 @@ namespace TouchScript.InputSources
         #endregion
 
         #region Protected methods
+
+        /// <summary>
+        /// Initializes the input source.
+        /// </summary>
+        protected virtual void init() {}
 
         /// <summary>
         /// Adds the pointer to the system.

--- a/Source/Assets/TouchScript/Scripts/InputSources/InputSource.cs
+++ b/Source/Assets/TouchScript/Scripts/InputSources/InputSource.cs
@@ -48,7 +48,7 @@ namespace TouchScript.InputSources
 		protected bool basicEditor = true;
 
 		private ICoordinatesRemapper coordinatesRemapper;
-        private TouchManagerInstance manager;
+        private TouchManagerInstance touchManager;
 
         #endregion
 
@@ -85,9 +85,9 @@ namespace TouchScript.InputSources
         /// </summary>
         protected virtual void OnEnable()
         {
-            manager = TouchManagerInstance.Instance;
-            if (manager == null) throw new InvalidOperationException("TouchManager instance is required!");
-            manager.AddInput(this);
+            touchManager = TouchManagerInstance.Instance;
+            if (touchManager == null) throw new InvalidOperationException("TouchManager instance is required!");
+            touchManager.AddInput(this);
         }
 
         /// <summary>
@@ -95,10 +95,10 @@ namespace TouchScript.InputSources
         /// </summary>
         protected virtual void OnDisable()
         {
-            if (manager != null)
+            if (touchManager != null)
             {
-                manager.RemoveInput(this);
-                manager = null;
+                touchManager.RemoveInput(this);
+                touchManager = null;
             }
         }
 
@@ -112,7 +112,7 @@ namespace TouchScript.InputSources
         /// <param name="pointer">The pointer to add.</param>
         protected virtual void addPointer(Pointer pointer)
         {
-            manager.INTERNAL_AddPointer(pointer);
+            touchManager.INTERNAL_AddPointer(pointer);
         }
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace TouchScript.InputSources
         protected virtual void updatePointer(Pointer pointer)
         {
             if (pointer == null) return;
-            manager.INTERNAL_UpdatePointer(pointer.Id);
+            touchManager.INTERNAL_UpdatePointer(pointer.Id);
         }
 
         /// <summary>
@@ -132,7 +132,7 @@ namespace TouchScript.InputSources
         protected virtual void pressPointer(Pointer pointer)
         {
             if (pointer == null) return;
-            manager.INTERNAL_PressPointer(pointer.Id);
+            touchManager.INTERNAL_PressPointer(pointer.Id);
         }
 
         /// <summary>
@@ -143,7 +143,7 @@ namespace TouchScript.InputSources
         {
             if (pointer == null) return;
             pointer.Buttons &= ~Pointer.PointerButtonState.AnyButtonPressed;
-            manager.INTERNAL_ReleasePointer(pointer.Id);
+            touchManager.INTERNAL_ReleasePointer(pointer.Id);
         }
 
         /// <summary>
@@ -153,7 +153,7 @@ namespace TouchScript.InputSources
         protected virtual void removePointer(Pointer pointer)
         {
             if (pointer == null) return;
-            manager.INTERNAL_RemovePointer(pointer.Id);
+            touchManager.INTERNAL_RemovePointer(pointer.Id);
         }
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace TouchScript.InputSources
         protected virtual void cancelPointer(Pointer pointer)
         {
             if (pointer == null) return;
-            manager.INTERNAL_CancelPointer(pointer.Id);
+            touchManager.INTERNAL_CancelPointer(pointer.Id);
         }
 
         /// <summary>

--- a/Source/Assets/TouchScript/Scripts/InputSources/StandardInput.cs
+++ b/Source/Assets/TouchScript/Scripts/InputSources/StandardInput.cs
@@ -435,7 +435,7 @@ namespace TouchScript.InputSources
 #if UNITY_STANDALONE_WIN && !UNITY_EDITOR
         private void enableWindows7Touch()
         {
-            windows7PointerHandler = new Windows7PointerHandler(addPointer, updatePointer, pressPointer, releasePointer, removePointer, cancelPointer);
+            windows7PointerHandler = new Windows7PointerHandler(this, addPointer, updatePointer, pressPointer, releasePointer, removePointer, cancelPointer);
             Debug.Log("[TouchScript] Initialized Windows 7 pointer input.");
         }
 
@@ -450,7 +450,7 @@ namespace TouchScript.InputSources
 
         private void enableWindows8Touch()
         {
-            windows8PointerHandler = new Windows8PointerHandler(addPointer, updatePointer, pressPointer, releasePointer, removePointer, cancelPointer);
+            windows8PointerHandler = new Windows8PointerHandler(this, addPointer, updatePointer, pressPointer, releasePointer, removePointer, cancelPointer);
             windows8PointerHandler.MouseInPointer = windows8Mouse;
             Debug.Log("[TouchScript] Initialized Windows 8 pointer input.");
         }

--- a/Source/Assets/TouchScript/Scripts/InputSources/StandardInput.cs
+++ b/Source/Assets/TouchScript/Scripts/InputSources/StandardInput.cs
@@ -145,8 +145,6 @@ namespace TouchScript.InputSources
 
         private static StandardInput instance;
 
-#pragma warning disable CS0414
-
 		[SerializeField]
         [HideInInspector]
         private bool generalProps; // Used in the custom inspector
@@ -158,8 +156,6 @@ namespace TouchScript.InputSources
 		[SerializeField]
 		[HideInInspector]
 		private bool webglProps; // Used in the custom inspector
-
-#pragma warning restore CS0414
 
 		[SerializeField]
         private Windows8APIType windows8API = Windows8APIType.Windows8;

--- a/Source/Assets/TouchScript/Scripts/Layers/FullscreenLayer.cs
+++ b/Source/Assets/TouchScript/Scripts/Layers/FullscreenLayer.cs
@@ -70,7 +70,20 @@ namespace TouchScript.Layers
                 _camera = value;
                 if (_camera == null) Type = LayerType.Global;
                 else Type = LayerType.Camera;
-                setName();
+            }
+        }
+
+        /// <inheritdoc />
+        public override string Name
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(layerName))
+                {
+                    if (_camera == null) return "Global Fullscreen";
+                    return "Fullscreen @ " + _camera.name;
+                }
+                return layerName;
             }
         }
 
@@ -139,13 +152,6 @@ namespace TouchScript.Layers
         #region Protected functions
 
         /// <inheritdoc />
-        protected override void setName()
-        {
-            if (_camera == null) Name = "Global Fullscreen";
-            else Name = "Fullscreen @ " + _camera.name;
-        }
-
-        /// <inheritdoc />
         protected override ProjectionParams createProjectionParams()
         {
             if (_camera) return new CameraProjectionParams(_camera);
@@ -168,7 +174,6 @@ namespace TouchScript.Layers
                     if (_camera == null) Debug.LogError("No Main camera found!");
                     break;
             }
-            setName();
         }
 
         private void cacheCameraTransform()

--- a/Source/Assets/TouchScript/Scripts/Layers/StandardLayer.cs
+++ b/Source/Assets/TouchScript/Scripts/Layers/StandardLayer.cs
@@ -98,6 +98,20 @@ namespace TouchScript.Layers
         }
 
         /// <inheritdoc />
+        public override string Name
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(layerName))
+                {
+                    if (_camera == null) return base.Name;
+                    return _camera.name;
+                }
+                return layerName;
+            }
+        }
+
+        /// <inheritdoc />
         public override Vector3 WorldProjectionNormal
         {
             get
@@ -300,14 +314,6 @@ namespace TouchScript.Layers
         protected override ProjectionParams createProjectionParams()
         {
             return new CameraProjectionParams(_camera);
-        }
-
-        /// <inheritdoc />
-        protected override void setName()
-        {
-            if (string.IsNullOrEmpty(Name))
-                if (_camera != null) Name = _camera.name;
-                else Name = "Layer";
         }
 
         #endregion

--- a/Source/Assets/TouchScript/Scripts/Layers/StandardLayer.cs
+++ b/Source/Assets/TouchScript/Scripts/Layers/StandardLayer.cs
@@ -265,7 +265,11 @@ namespace TouchScript.Layers
         private void OnDisable()
         {
             if (!Application.isPlaying) return;
-            if (inputModule != null) inputModule.INTERNAL_Release();
+            if (inputModule != null) 
+            {
+                inputModule.INTERNAL_Release();
+                inputModule = null;
+            }
             if (TouchManager.Instance != null) TouchManager.Instance.FrameStarted -= frameStartedHandler;
         }
 

--- a/Source/Assets/TouchScript/Scripts/Layers/StandardLayer.cs
+++ b/Source/Assets/TouchScript/Scripts/Layers/StandardLayer.cs
@@ -126,7 +126,7 @@ namespace TouchScript.Layers
 #endif
         private static RaycastHit2D[] raycastHits2D = new RaycastHit2D[20];
 
-#pragma warning disable CS0414
+#pragma warning disable 0414
 
 		[SerializeField]
 		[HideInInspector]
@@ -136,7 +136,7 @@ namespace TouchScript.Layers
         [HideInInspector]
         private bool advancedProps; // is used to save if advanced properties are opened or closed
 
-#pragma warning restore CS0414
+#pragma warning restore 0414
 
 		[SerializeField]
         [HideInInspector]
@@ -251,7 +251,10 @@ namespace TouchScript.Layers
         private void OnEnable()
         {
             if (!Application.isPlaying) return;
-            TouchManager.Instance.FrameStarted += frameStartedHandler;
+
+            var touchManager = TouchManager.Instance;
+            if (touchManager != null) touchManager.FrameStarted += frameStartedHandler;
+
             StartCoroutine(lateEnable());
         }
 
@@ -270,7 +273,9 @@ namespace TouchScript.Layers
                 inputModule.INTERNAL_Release();
                 inputModule = null;
             }
-            if (TouchManager.Instance != null) TouchManager.Instance.FrameStarted -= frameStartedHandler;
+
+            var touchManager = TouchManager.Instance;
+            if (touchManager != null) touchManager.FrameStarted -= frameStartedHandler;
         }
 
 		[ContextMenu("Basic Editor")]
@@ -338,7 +343,7 @@ namespace TouchScript.Layers
             var ray = _camera.ScreenPointToRay(position);
 
             int count;
-            bool exclusiveSet = manager.HasExclusive;
+            bool exclusiveSet = layerManager.HasExclusive;
 
             if (hit3DObjects)
             {
@@ -361,7 +366,7 @@ namespace TouchScript.Layers
                         for (var i = 0; i < count; i++)
                         {
                             raycast = raycastHits[i];
-                            if (exclusiveSet && !manager.IsExclusive(raycast.transform)) continue;
+                            if (exclusiveSet && !layerManager.IsExclusive(raycast.transform)) continue;
                             raycastHitList.Add(raycast);
                         }
                         if (raycastHitList.Count == 0) return HitResult.Miss;
@@ -381,7 +386,7 @@ namespace TouchScript.Layers
                     }
 
                     raycast = raycastHits[0];
-                    if (exclusiveSet && !manager.IsExclusive(raycast.transform)) return HitResult.Miss;
+                    if (exclusiveSet && !layerManager.IsExclusive(raycast.transform)) return HitResult.Miss;
                     if (useHitFilters) return doHit(pointer, raycast, out hit);
                     hit = new HitData(raycast, this);
                     return HitResult.Hit;
@@ -389,7 +394,7 @@ namespace TouchScript.Layers
                 for (var i = 0; i < count; i++)
                 {
                     var raycast = raycastHits[i];
-                    if (exclusiveSet && !manager.IsExclusive(raycast.transform)) continue;
+                    if (exclusiveSet && !layerManager.IsExclusive(raycast.transform)) continue;
                     hitList.Add(new HitData(raycastHits[i], this));
                 }
             }
@@ -400,7 +405,7 @@ namespace TouchScript.Layers
                 for (var i = 0; i < count; i++)
                 {
                     var raycast = raycastHits2D[i];
-                    if (exclusiveSet && !manager.IsExclusive(raycast.transform)) continue;
+                    if (exclusiveSet && !layerManager.IsExclusive(raycast.transform)) continue;
                     hitList.Add(new HitData(raycast, this));
                 }
             }
@@ -496,14 +501,14 @@ namespace TouchScript.Layers
             var position = pointer.Position;
             var foundGraphics = GraphicRegistry.GetGraphicsForCanvas(canvas);
             var count = foundGraphics.Count;
-            var exclusiveSet = manager.HasExclusive;
+            var exclusiveSet = layerManager.HasExclusive;
 
             for (var i = 0; i < count; i++)
             {
                 var graphic = foundGraphics[i];
                 var t = graphic.transform;
 
-                if (exclusiveSet && !manager.IsExclusive(t)) continue;
+                if (exclusiveSet && !layerManager.IsExclusive(t)) continue;
 
                 if ((layerMask.value != -1) && ((layerMask.value & (1 << graphic.gameObject.layer)) == 0)) continue;
 

--- a/Source/Assets/TouchScript/Scripts/Layers/TouchLayer.cs
+++ b/Source/Assets/TouchScript/Scripts/Layers/TouchLayer.cs
@@ -76,7 +76,7 @@ namespace TouchScript.Layers
         /// <summary>
         /// Layer manager.
         /// </summary>
-        protected ILayerManager manager;
+        protected ILayerManager layerManager;
 
         #endregion
 
@@ -128,7 +128,7 @@ namespace TouchScript.Layers
             setName();
             if (!Application.isPlaying) return;
 
-            manager = LayerManager.Instance;
+            layerManager = LayerManager.Instance;
             layerProjectionParams = createProjectionParams();
             StartCoroutine(lateAwake());
         }
@@ -138,7 +138,7 @@ namespace TouchScript.Layers
             yield return null;
 
             // Add ourselves after TouchManager finished adding layers in order
-            manager.AddLayer(this, -1, false);
+            if (layerManager != null) layerManager.AddLayer(this, -1, false);
         }
 
         // To be able to turn layers off
@@ -149,10 +149,10 @@ namespace TouchScript.Layers
         /// </summary>
         protected virtual void OnDestroy()
         {
-            if (!Application.isPlaying || TouchManager.Instance == null) return;
+            if (!Application.isPlaying) return;
 
             StopAllCoroutines();
-            manager.RemoveLayer(this);
+            if (layerManager != null) layerManager.RemoveLayer(this);
         }
 
         #endregion

--- a/Source/Assets/TouchScript/Scripts/Layers/TouchLayer.cs
+++ b/Source/Assets/TouchScript/Scripts/Layers/TouchLayer.cs
@@ -48,7 +48,18 @@ namespace TouchScript.Layers
         /// <summary>
         /// Pointer layer's name.
         /// </summary>
-        public string Name;
+        public virtual string Name
+        {
+            get 
+            {
+                if (string.IsNullOrEmpty(layerName)) return "Layer";
+                return layerName;
+            }
+            set
+            {
+                layerName = value;
+            }
+        }
 
         /// <summary>
         /// Layers screen to world projection normal.
@@ -77,6 +88,9 @@ namespace TouchScript.Layers
         /// Layer manager.
         /// </summary>
         protected ILayerManager layerManager;
+
+        [SerializeField]
+        protected string layerName;
 
         #endregion
 
@@ -125,7 +139,6 @@ namespace TouchScript.Layers
         /// </summary>
         protected virtual void Awake()
         {
-            setName();
             if (!Application.isPlaying) return;
 
             layerManager = LayerManager.Instance;
@@ -217,14 +230,6 @@ namespace TouchScript.Layers
             }
 
             return hitResult;
-        }
-
-        /// <summary>
-        /// Updates pointer layers's name.
-        /// </summary>
-        protected virtual void setName()
-        {
-            if (string.IsNullOrEmpty(Name)) Name = "Layer";
         }
 
         /// <summary>

--- a/Source/Assets/TouchScript/Scripts/Layers/UI/TouchScriptInputModule.cs
+++ b/Source/Assets/TouchScript/Scripts/Layers/UI/TouchScriptInputModule.cs
@@ -492,14 +492,17 @@ namespace TouchScript.Layers.UI
 						var press = pointer.GetPressData();
 						if (press.Type != HitData.HitType.UI) continue;
 					}
-                    else
-                    {
-    					// Don't update the pointer if it is not over an UI element
-                        if (over.Type != HitData.HitType.UI) continue;
-                    }
 
                     PointerEventData data;
                     GetPointerData(pointer.Id, out data, true);
+
+                    // If not over an UI element this and previous frame, don't process further.
+                    // Need to check the previous hover state to properly process leaving a UI element.
+                    if (over.Type != HitData.HitType.UI) 
+                    {
+                        if (data.hovered.Count == 0) continue;
+                    }
+
                     data.Reset();
                     var target = over.Target;
                     var currentOverGo = target == null ? null : target.gameObject;

--- a/Source/Assets/TouchScript/Scripts/Layers/UI/TouchScriptInputModule.cs
+++ b/Source/Assets/TouchScript/Scripts/Layers/UI/TouchScriptInputModule.cs
@@ -689,7 +689,7 @@ namespace TouchScript.Layers.UI
                     // so that if we moused over somethign that ignored it before
                     // due to having pressed on something else
                     // it now gets it.
-                    if (currentOverGo != data.pointerEnter)
+                    if (pointer is MousePointer && currentOverGo != data.pointerEnter)
                     {
                         input.HandlePointerExitAndEnter(data, null);
                         input.HandlePointerExitAndEnter(data, currentOverGo);

--- a/Source/Assets/TouchScript/Scripts/Layers/UI/TouchScriptInputModule.cs
+++ b/Source/Assets/TouchScript/Scripts/Layers/UI/TouchScriptInputModule.cs
@@ -29,9 +29,11 @@ namespace TouchScript.Layers.UI
         {
             get
             {
-                if (shuttingDown) return null;
-                if (instance == null)
+                if (object.Equals(instance, null))
                 {
+                    // Create an instance if it hasn't been created yet.
+                    // Don't recreate it if the instance was destroyed. 
+                    // Should happen only when the app is closing or editor is exiting Play Mode.
                     var es = EventSystem.current;
                     if (es == null)
                     {
@@ -60,7 +62,6 @@ namespace TouchScript.Layers.UI
 
         #region Private variables
 
-        private static bool shuttingDown = false;
         private static TouchScriptInputModule instance;
         private static FieldInfo raycastersProp;
         private static PropertyInfo canvasProp;
@@ -104,11 +105,6 @@ namespace TouchScript.Layers.UI
             disable();
             if (instance == this) instance = null;
             base.OnDisable();
-        }
-
-        private void OnApplicationQuit()
-        {
-            shuttingDown = true;
         }
 
         #endregion
@@ -198,26 +194,30 @@ namespace TouchScript.Layers.UI
         private void enable()
         {
             ui = new UIStandardInputModule(this);
-            TouchManager.Instance.PointersAdded += ui.ProcessAdded;
-            TouchManager.Instance.PointersUpdated += ui.ProcessUpdated;
-            TouchManager.Instance.PointersPressed += ui.ProcessPressed;
-            TouchManager.Instance.PointersReleased += ui.ProcessReleased;
-            TouchManager.Instance.PointersRemoved += ui.ProcessRemoved;
-            TouchManager.Instance.PointersCancelled += ui.ProcessCancelled;
+            var touchManager = TouchManager.Instance;
+            if (touchManager == null) return;
+
+            touchManager.PointersAdded += ui.ProcessAdded;
+            touchManager.PointersUpdated += ui.ProcessUpdated;
+            touchManager.PointersPressed += ui.ProcessPressed;
+            touchManager.PointersReleased += ui.ProcessReleased;
+            touchManager.PointersRemoved += ui.ProcessRemoved;
+            touchManager.PointersCancelled += ui.ProcessCancelled;
         }
 
         private void disable()
         {
-            if (TouchManager.Instance != null && ui != null)
-            {
-                TouchManager.Instance.PointersAdded -= ui.ProcessAdded;
-                TouchManager.Instance.PointersUpdated -= ui.ProcessUpdated;
-                TouchManager.Instance.PointersPressed -= ui.ProcessPressed;
-                TouchManager.Instance.PointersReleased -= ui.ProcessReleased;
-                TouchManager.Instance.PointersRemoved -= ui.ProcessRemoved;
-                TouchManager.Instance.PointersCancelled -= ui.ProcessCancelled;
-            }
             refCount = 0;
+
+            var touchManager = TouchManager.Instance;
+            if (touchManager == null || ui == null) return;
+
+            touchManager.PointersAdded -= ui.ProcessAdded;
+            touchManager.PointersUpdated -= ui.ProcessUpdated;
+            touchManager.PointersPressed -= ui.ProcessPressed;
+            touchManager.PointersReleased -= ui.ProcessReleased;
+            touchManager.PointersRemoved -= ui.ProcessRemoved;
+            touchManager.PointersCancelled -= ui.ProcessCancelled;
         }
 
         #endregion

--- a/Source/Assets/TouchScript/Scripts/Layers/UI/TouchScriptInputModule.cs
+++ b/Source/Assets/TouchScript/Scripts/Layers/UI/TouchScriptInputModule.cs
@@ -77,7 +77,7 @@ namespace TouchScript.Layers.UI
         {
             if (raycastersProp == null)
             {
-                raycastersProp = Type.GetType(Assembly.CreateQualifiedName("UnityEngine.UI", "UnityEngine.EventSystems.RaycasterManager")).
+                raycastersProp = Type.GetType("UnityEngine.EventSystems.RaycasterManager, UnityEngine.UI").
                                      GetField("s_Raycasters", BindingFlags.NonPublic | BindingFlags.Static);
                 canvasProp = typeof(GraphicRaycaster).GetProperty("canvas", BindingFlags.NonPublic | BindingFlags.Instance);
             }

--- a/Source/Assets/TouchScript/Scripts/TouchManager.cs
+++ b/Source/Assets/TouchScript/Scripts/TouchManager.cs
@@ -412,19 +412,23 @@ namespace TouchScript
 
         private void Awake()
         {
-            if (Instance == null) return;
+            var touchManager = Instance;
+            if (touchManager == null) return;
 
 #if TOUCHSCRIPT_DEBUG
-            if (DebugMode) (Instance as TouchManagerInstance).DebugMode = true;
+            if (DebugMode) (touchManager as TouchManagerInstance).DebugMode = true;
 #endif
 
-            Instance.DisplayDevice = displayDevice as IDisplayDevice;
-            Instance.ShouldCreateCameraLayer = ShouldCreateCameraLayer;
-            Instance.ShouldCreateStandardInput = ShouldCreateStandardInput;
+            touchManager.DisplayDevice = displayDevice as IDisplayDevice;
+            touchManager.ShouldCreateCameraLayer = ShouldCreateCameraLayer;
+            touchManager.ShouldCreateStandardInput = ShouldCreateStandardInput;
+
+            var layerManager = LayerManager.Instance;
+            if (layerManager == null) return;
             for (var i = 0; i < layers.Count; i++)
             {
                 var layer = layers[i];
-                if (layer != null) LayerManager.Instance.AddLayer(layer, i);
+                if (layer != null) layerManager.AddLayer(layer, i);
             }
         }
 
@@ -453,7 +457,8 @@ namespace TouchScript
         private void updateSendMessageSubscription()
         {
             if (!Application.isPlaying) return;
-            if (Instance == null) return;
+            var touchManager = Instance;
+            if (touchManager == null) return;
 
             if (sendMessageTarget == null) sendMessageTarget = gameObject;
 
@@ -461,29 +466,30 @@ namespace TouchScript
 
             if (!useSendMessage) return;
 
-            if ((SendMessageEvents & MessageType.FrameStarted) != 0) Instance.FrameStarted += frameStartedSendMessageHandler;
-            if ((SendMessageEvents & MessageType.FrameFinished) != 0) Instance.FrameFinished += frameFinishedSendMessageHandler;
-            if ((SendMessageEvents & MessageType.PointersAdded) != 0) Instance.PointersAdded += pointersAddedSendMessageHandler;
-            if ((SendMessageEvents & MessageType.PointersUpdated) != 0) Instance.PointersUpdated += pointersUpdatedSendMessageHandler;
-            if ((SendMessageEvents & MessageType.PointersPressed) != 0) Instance.PointersPressed += pointersPressedSendMessageHandler;
-            if ((SendMessageEvents & MessageType.PointersReleased) != 0) Instance.PointersReleased += pointersReleasedSendMessageHandler;
-            if ((SendMessageEvents & MessageType.PointersRemoved) != 0) Instance.PointersRemoved += pointersRemovedSendMessageHandler;
-            if ((SendMessageEvents & MessageType.PointersCancelled) != 0) Instance.PointersCancelled += pointersCancelledSendMessageHandler;
+            if ((SendMessageEvents & MessageType.FrameStarted) != 0) touchManager.FrameStarted += frameStartedSendMessageHandler;
+            if ((SendMessageEvents & MessageType.FrameFinished) != 0) touchManager.FrameFinished += frameFinishedSendMessageHandler;
+            if ((SendMessageEvents & MessageType.PointersAdded) != 0) touchManager.PointersAdded += pointersAddedSendMessageHandler;
+            if ((SendMessageEvents & MessageType.PointersUpdated) != 0) touchManager.PointersUpdated += pointersUpdatedSendMessageHandler;
+            if ((SendMessageEvents & MessageType.PointersPressed) != 0) touchManager.PointersPressed += pointersPressedSendMessageHandler;
+            if ((SendMessageEvents & MessageType.PointersReleased) != 0) touchManager.PointersReleased += pointersReleasedSendMessageHandler;
+            if ((SendMessageEvents & MessageType.PointersRemoved) != 0) touchManager.PointersRemoved += pointersRemovedSendMessageHandler;
+            if ((SendMessageEvents & MessageType.PointersCancelled) != 0) touchManager.PointersCancelled += pointersCancelledSendMessageHandler;
         }
 
         private void removeSendMessageSubscriptions()
         {
             if (!Application.isPlaying) return;
-            if (Instance == null) return;
+            var touchManager = Instance;
+            if (touchManager == null) return;
 
-            Instance.FrameStarted -= frameStartedSendMessageHandler;
-            Instance.FrameFinished -= frameFinishedSendMessageHandler;
-            Instance.PointersAdded -= pointersAddedSendMessageHandler;
-            Instance.PointersUpdated -= pointersUpdatedSendMessageHandler;
-            Instance.PointersPressed -= pointersPressedSendMessageHandler;
-            Instance.PointersReleased -= pointersReleasedSendMessageHandler;
-            Instance.PointersRemoved -= pointersRemovedSendMessageHandler;
-            Instance.PointersCancelled -= pointersCancelledSendMessageHandler;
+            touchManager.FrameStarted -= frameStartedSendMessageHandler;
+            touchManager.FrameFinished -= frameFinishedSendMessageHandler;
+            touchManager.PointersAdded -= pointersAddedSendMessageHandler;
+            touchManager.PointersUpdated -= pointersUpdatedSendMessageHandler;
+            touchManager.PointersPressed -= pointersPressedSendMessageHandler;
+            touchManager.PointersReleased -= pointersReleasedSendMessageHandler;
+            touchManager.PointersRemoved -= pointersRemovedSendMessageHandler;
+            touchManager.PointersCancelled -= pointersCancelledSendMessageHandler;
         }
 
         private void pointersAddedSendMessageHandler(object sender, PointerEventArgs e)
@@ -537,35 +543,37 @@ namespace TouchScript
         private void updateUnityEventsSubscription()
         {
             if (!Application.isPlaying) return;
-            if (Instance == null) return;
+            var touchManager = Instance;
+            if (touchManager == null) return;
 
             removeUnityEventsSubscriptions();
 
             if (!useUnityEvents) return;
 
-            Instance.FrameStarted += frameStartedUnityEventsHandler;
-            Instance.FrameFinished += frameFinishedUnityEventsHandler;
-            Instance.PointersAdded += pointersAddedUnityEventsHandler;
-            Instance.PointersUpdated += pointersUpdatedUnityEventsHandler;
-            Instance.PointersPressed += pointersPressedUnityEventsHandler;
-            Instance.PointersReleased += pointersReleasedUnityEventsHandler;
-            Instance.PointersRemoved += pointersRemovedUnityEventsHandler;
-            Instance.PointersCancelled += pointersCancelledUnityEventsHandler;
+            touchManager.FrameStarted += frameStartedUnityEventsHandler;
+            touchManager.FrameFinished += frameFinishedUnityEventsHandler;
+            touchManager.PointersAdded += pointersAddedUnityEventsHandler;
+            touchManager.PointersUpdated += pointersUpdatedUnityEventsHandler;
+            touchManager.PointersPressed += pointersPressedUnityEventsHandler;
+            touchManager.PointersReleased += pointersReleasedUnityEventsHandler;
+            touchManager.PointersRemoved += pointersRemovedUnityEventsHandler;
+            touchManager.PointersCancelled += pointersCancelledUnityEventsHandler;
         }
 
         private void removeUnityEventsSubscriptions()
         {
             if (!Application.isPlaying) return;
-            if (Instance == null) return;
+            var touchManager = Instance;
+            if (touchManager == null) return;
 
-            Instance.FrameStarted -= frameStartedUnityEventsHandler;
-            Instance.FrameFinished -= frameFinishedUnityEventsHandler;
-            Instance.PointersAdded -= pointersAddedUnityEventsHandler;
-            Instance.PointersUpdated -= pointersUpdatedUnityEventsHandler;
-            Instance.PointersPressed -= pointersPressedUnityEventsHandler;
-            Instance.PointersReleased -= pointersReleasedUnityEventsHandler;
-            Instance.PointersRemoved -= pointersRemovedUnityEventsHandler;
-            Instance.PointersCancelled -= pointersCancelledUnityEventsHandler;
+            touchManager.FrameStarted -= frameStartedUnityEventsHandler;
+            touchManager.FrameFinished -= frameFinishedUnityEventsHandler;
+            touchManager.PointersAdded -= pointersAddedUnityEventsHandler;
+            touchManager.PointersUpdated -= pointersUpdatedUnityEventsHandler;
+            touchManager.PointersPressed -= pointersPressedUnityEventsHandler;
+            touchManager.PointersReleased -= pointersReleasedUnityEventsHandler;
+            touchManager.PointersRemoved -= pointersRemovedUnityEventsHandler;
+            touchManager.PointersCancelled -= pointersCancelledUnityEventsHandler;
         }
 
         private void pointersAddedUnityEventsHandler(object sender, PointerEventArgs e)

--- a/Source/Assets/TouchScript/Scripts/TouchManager.cs
+++ b/Source/Assets/TouchScript/Scripts/TouchManager.cs
@@ -362,7 +362,7 @@ namespace TouchScript
         /// <returns><c>true</c> if position is invalid; otherwise, <c>false</c>.</returns>
         public static bool IsInvalidPosition(Vector2 position)
         {
-			return position.x == INVALID_POSITION.x && position.y == INVALID_POSITION.y;
+            return float.IsNaN(position.x) && float.IsNaN(position.y);
         }
 
         #endregion

--- a/Source/Assets/TouchScript/Scripts/TouchManager.cs
+++ b/Source/Assets/TouchScript/Scripts/TouchManager.cs
@@ -369,13 +369,13 @@ namespace TouchScript
 
         #region Private variables
 
-        #pragma warning disable CS0414
+#pragma warning disable 0414
 
         [SerializeField]
         [HideInInspector]
         private bool basicEditor = true;
 
-        #pragma warning restore CS0414
+#pragma warning restore 0414
 
 		[SerializeField]
         private Object displayDevice;

--- a/Source/ProjectSettings/DynamicsManager.asset
+++ b/Source/ProjectSettings/DynamicsManager.asset
@@ -3,13 +3,18 @@
 --- !u!55 &1
 PhysicsManager:
   m_ObjectHideFlags: 0
-  m_Gravity: {x: 0, y: -9.81000042, z: 0}
+  serializedVersion: 3
+  m_Gravity: {x: 0, y: -9.81, z: 0}
   m_DefaultMaterial: {fileID: 0}
   m_BounceThreshold: 2
-  m_SleepVelocity: .150000006
-  m_SleepAngularVelocity: .140000001
-  m_MaxAngularVelocity: 7
-  m_MinPenetrationForPenalty: .00999999978
-  m_SolverIterationCount: 6
-  m_RaycastsHitTriggers: 0
+  m_SleepThreshold: 0.005
+  m_DefaultContactOffset: 0.01
+  m_DefaultSolverIterations: 6
+  m_DefaultSolverVelocityIterations: 1
+  m_QueriesHitBackfaces: 0
+  m_QueriesHitTriggers: 0
+  m_EnableAdaptiveForce: 0
+  m_EnablePCM: 1
   m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_AutoSimulation: 1
+  m_AutoSyncTransforms: 1

--- a/Source/ProjectSettings/GraphicsSettings.asset
+++ b/Source/ProjectSettings/GraphicsSettings.asset
@@ -3,16 +3,31 @@
 --- !u!30 &1
 GraphicsSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 5
+  serializedVersion: 12
   m_Deferred:
     m_Mode: 1
     m_Shader: {fileID: 69, guid: 0000000000000000f000000000000000, type: 0}
   m_DeferredReflections:
     m_Mode: 1
     m_Shader: {fileID: 74, guid: 0000000000000000f000000000000000, type: 0}
+  m_ScreenSpaceShadows:
+    m_Mode: 1
+    m_Shader: {fileID: 64, guid: 0000000000000000f000000000000000, type: 0}
   m_LegacyDeferred:
     m_Mode: 1
     m_Shader: {fileID: 63, guid: 0000000000000000f000000000000000, type: 0}
+  m_DepthNormals:
+    m_Mode: 1
+    m_Shader: {fileID: 62, guid: 0000000000000000f000000000000000, type: 0}
+  m_MotionVectors:
+    m_Mode: 1
+    m_Shader: {fileID: 75, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightHalo:
+    m_Mode: 1
+    m_Shader: {fileID: 105, guid: 0000000000000000f000000000000000, type: 0}
+  m_LensFlare:
+    m_Mode: 1
+    m_Shader: {fileID: 102, guid: 0000000000000000f000000000000000, type: 0}
   m_AlwaysIncludedShaders:
   - {fileID: 7, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 15104, guid: 0000000000000000f000000000000000, type: 0}
@@ -20,18 +35,29 @@ GraphicsSettings:
   - {fileID: 15106, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10782, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 16000, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 16002, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
-  m_ShaderSettings:
-    useScreenSpaceShadows: 1
-  m_BuildTargetShaderSettings: []
+  m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
+    type: 0}
+  m_CustomRenderPipeline: {fileID: 0}
+  m_TransparencySortMode: 0
+  m_TransparencySortAxis: {x: 0, y: 0, z: 1}
+  m_DefaultRenderingPath: 1
+  m_DefaultMobileRenderingPath: 1
+  m_TierSettings: []
   m_LightmapStripping: 0
   m_FogStripping: 0
+  m_InstancingStripping: 0
   m_LightmapKeepPlain: 1
   m_LightmapKeepDirCombined: 1
-  m_LightmapKeepDirSeparate: 1
   m_LightmapKeepDynamicPlain: 1
   m_LightmapKeepDynamicDirCombined: 1
-  m_LightmapKeepDynamicDirSeparate: 1
+  m_LightmapKeepShadowMask: 1
+  m_LightmapKeepSubtractive: 1
   m_FogKeepLinear: 1
   m_FogKeepExp: 1
   m_FogKeepExp2: 1
+  m_AlbedoSwatchInfos: []
+  m_LightsUseLinearIntensity: 0
+  m_LightsUseColorTemperature: 0

--- a/Source/ProjectSettings/Physics2DSettings.asset
+++ b/Source/ProjectSettings/Physics2DSettings.asset
@@ -3,9 +3,35 @@
 --- !u!19 &1
 Physics2DSettings:
   m_ObjectHideFlags: 0
-  m_Gravity: {x: 0, y: -9.81000042}
+  serializedVersion: 3
+  m_Gravity: {x: 0, y: -9.81}
   m_DefaultMaterial: {fileID: 0}
   m_VelocityIterations: 8
   m_PositionIterations: 3
-  m_RaycastsHitTriggers: 1
+  m_VelocityThreshold: 1
+  m_MaxLinearCorrection: 0.2
+  m_MaxAngularCorrection: 8
+  m_MaxTranslationSpeed: 100
+  m_MaxRotationSpeed: 360
+  m_BaumgarteScale: 0.2
+  m_BaumgarteTimeOfImpactScale: 0.75
+  m_TimeToSleep: 0.5
+  m_LinearSleepTolerance: 0.01
+  m_AngularSleepTolerance: 2
+  m_DefaultContactOffset: 0.01
+  m_AutoSimulation: 1
+  m_QueriesHitTriggers: 1
+  m_QueriesStartInColliders: 1
+  m_ChangeStopsCallbacks: 0
+  m_CallbacksOnDisable: 1
+  m_AutoSyncTransforms: 1
+  m_AlwaysShowColliders: 0
+  m_ShowColliderSleep: 1
+  m_ShowColliderContacts: 0
+  m_ShowColliderAABB: 0
+  m_ContactArrowScale: 0.2
+  m_ColliderAwakeColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.7529412}
+  m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
+  m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
+  m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
   m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/Source/ProjectSettings/ProjectSettings.asset
+++ b/Source/ProjectSettings/ProjectSettings.asset
@@ -236,6 +236,7 @@ PlayerSettings:
       m_Icon: {fileID: 0}
       m_Width: 128
       m_Height: 128
+      m_Kind: 0
   m_BuildTargetBatching: []
   m_BuildTargetGraphicsAPIs:
   - m_BuildTarget: WindowsStandaloneSupport
@@ -382,6 +383,9 @@ PlayerSettings:
   switchUdpSendBufferSize: 9
   switchUdpReceiveBufferSize: 42
   switchSocketBufferEfficiency: 4
+  switchSocketInitializeEnabled: 1
+  switchNetworkInterfaceManagerInitializeEnabled: 1
+  switchPlayerConnectionEnabled: 1
   ps4NPAgeRating: 12
   ps4NPTitleSecret: 
   ps4NPTrophyPackPath: 

--- a/Source/ProjectSettings/ProjectVersion.txt
+++ b/Source/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 5.6.1p4
+m_EditorVersion: 5.6.2p4

--- a/Source/ProjectSettings/ProjectVersion.txt
+++ b/Source/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 5.6.2p4
+m_EditorVersion: 5.6.4f1


### PR DESCRIPTION
In Unity 2017.2 (and possibly other versions), mouse handling and touch handling is slightly different when a pointer is released. The TouchScript input module currently emits events the same way for both mouse and touch pointers. This change should match what the Unity UI Standard Input module is doing by only emitting some events during release for mouse pointers, not touch pointers.

It may require more attention for Unity 2017.3+ and other pointer input types.