### PR TITLE
Changed Unity UI pointer release events to only emit for mouse pointers.

### DIFF
--- a/Source/Assets/TouchScript/Scripts/Layers/UI/TouchScriptInputModule.cs
+++ b/Source/Assets/TouchScript/Scripts/Layers/UI/TouchScriptInputModule.cs
@@ -689,7 +689,7 @@ namespace TouchScript.Layers.UI
                     // so that if we moused over somethign that ignored it before
                     // due to having pressed on something else
                     // it now gets it.
-                    if (currentOverGo != data.pointerEnter)
+                    if (pointer is MousePointer && currentOverGo != data.pointerEnter)
                     {
                         input.HandlePointerExitAndEnter(data, null);
                         input.HandlePointerExitAndEnter(data, currentOverGo);


### PR DESCRIPTION
In Unity 2017.2 (and possibly other versions), mouse handling and touch handling is slightly different when a pointer is released. The TouchScript input module currently emits events the same way for both mouse and touch pointers. This change should match what the Unity UI Standard Input module is doing by only emitting some events during release for mouse pointers, not touch pointers.

It may require more attention for Unity 2017.3+ and other pointer input types.