### PR TITLE
Fix StandardInput singleton bug

### DIFF
--- a/Source/Assets/TouchScript/Scripts/InputSources/StandardInput.cs
+++ b/Source/Assets/TouchScript/Scripts/InputSources/StandardInput.cs
@@ -267,7 +267,7 @@ namespace TouchScript.InputSources
         /// <inheritdoc />
         protected override void OnEnable()
         {
-            if (instance != null) Destroy(instance);
+            if (instance != null && instance != this) Destroy(instance);
             instance = this;
 
             base.OnEnable();


### PR DESCRIPTION
### What's the bug?
Previously the logic only checked whether the variable storing the singleton instance was null and if not destroyed it. However that doesn't take into account that the StandardInput component may have been disabled and then re-enabled and that this is the same instance as the one we had previously stored as the singleton instance.

This branch fixes that by adding a check for whether this is the same instance as we stored. 