### PR TITLE
Fix gesture center when switching FullscreenLayer to new camera

### DIFF
--- a/Source/Assets/TouchScript/Scripts/Layers/FullscreenLayer.cs
+++ b/Source/Assets/TouchScript/Scripts/Layers/FullscreenLayer.cs
@@ -70,6 +70,7 @@ namespace TouchScript.Layers
                 _camera = value;
                 if (_camera == null) Type = LayerType.Global;
                 else Type = LayerType.Camera;
+                cacheCameraTransform();
                 setName();
             }
         }
@@ -173,6 +174,7 @@ namespace TouchScript.Layers
 
         private void cacheCameraTransform()
         {
+            layerProjectionParams = createProjectionParams(); // update projection params in case camera viewport rect changes
             if (_camera == null) cameraTransform = null;
             else cameraTransform = _camera.transform;
         }


### PR DESCRIPTION
Issue: In case the new camera viewport rect is different than the original (e.g. 0.5 height instead of height 1) , the gesture center is based on the original camera viewport rect
Fix: recalculate projection params to pick up updated viewport rect if needed.